### PR TITLE
Add state models

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,6 +17,7 @@ class TasksController < ApplicationController
     @task = Task.new
     @users = User.all
     @projects = Project.all
+    @states = State.all
 
     project_id = params[:project_id]
     unless project_id.nil?
@@ -28,6 +29,7 @@ class TasksController < ApplicationController
   def edit
     @users = User.all
     @projects = Project.all
+    @states = State.all
   end
 
   # POST /tasks or /tasks.json
@@ -70,6 +72,6 @@ class TasksController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def task_params
-    params.require(:task).permit(:assigner_id, :due_at, :content, :description, :project_id)
+    params.require(:task).permit(:assigner_id, :due_at, :content, :description, :project_id, :status)
   end
 end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -1,0 +1,3 @@
+class State < ApplicationRecord
+  has_many :tasks
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ApplicationRecord
   belongs_to :user, foreign_key: 'creator_id'
   belongs_to :assigner, foreign_key: 'assigner_id', class_name: 'User'
   belongs_to :project, optional: true
+  belongs_to :state, foreign_key: 'status'
 
   def show_days_ago
     day = ((self.created_at - Time.zone.now)/60/60/24).abs.round.to_s

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -36,6 +36,11 @@
     <%= form.text_area :description, class: "border-2 w-full", rows: 10, placeholder: "タスクの説明を入力してください" %>
   </div>
 
+  <div class="field my-4">
+    <%= form.label :status, "状態", class: "text-xl block font-bold mb-2" %>
+    <%= form.select :status, @states.map { |s| [s.name, s.id] }, { include_blank: true }, class: "border-2 w-full" %>
+  </div>
+
   <div class="actions">
     <%= form.submit "保存", class: "bg-red-400 p-2 text-white rounded w-full" %>
   </div>

--- a/app/views/tasks/_task.json.jbuilder
+++ b/app/views/tasks/_task.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! task, :id, :content, :user_id, :created_at, :updated_at, :project_id
+json.extract! task, :id, :content, :user_id, :created_at, :updated_at, :project_id, :status
 json.url task_url(task, format: :json)

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,3 +1,3 @@
 <%= render 'layouts/h1', title: "タスク編集" %>
 
-<%= render 'form', task: @task, users: @users, project: @projects%>
+<%= render 'form', task: @task, users: @users, project: @projects, state: @states %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,3 +1,3 @@
 <%= render 'layouts/h1', title: "タスク新規作成" %>
 
-<%= render 'form', task: @task, users: @users , project: @projects%>
+<%= render 'form', task: @task, users: @users , project: @projects , state: @states %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -19,3 +19,8 @@
   <p class="text-xl block font-bold mb-2">所属プロジェクト</p>
   <%= link_to @task.project.name, @task.project %>
 </div>
+
+<div class="my-3">
+  <p class="text-xl block font-bold mb-2">状態</p>
+  <%= @task.state.name %>
+</div>

--- a/db/migrate/20210826072644_create_states.rb
+++ b/db/migrate/20210826072644_create_states.rb
@@ -1,0 +1,9 @@
+class CreateStates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :states do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210827073951_add_status_to_task.rb
+++ b/db/migrate/20210827073951_add_status_to_task.rb
@@ -1,0 +1,6 @@
+class AddStatusToTask < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :status, :integer
+    add_foreign_key :tasks, :states, column: :status
+  end
+end

--- a/db/migrate/20210914022849_add_column_to_states.rb
+++ b/db/migrate/20210914022849_add_column_to_states.rb
@@ -1,0 +1,7 @@
+class AddColumnToStates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :states, :priority, :int
+    add_column :states, :about, :string
+    add_column :states, :color, :string
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,8 +15,18 @@ projects = Project.create!([
                  { name: 'project2', user_id: users.first.id }
                ])
 
+status = State.create!([
+                 { name: 'todo'},
+                 { name: 'done'},
+                 { name: 'appoint'},
+                 { name: 'wait'},
+                 { name: 'someday'},
+                 { name: 'cancel'},
+                 { name: 'inbox'},
+                 { name: 'draft'},
+                ])
 
 Task.create!([
-              { content: 'task1', description: 'desc1', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id },
-              { content: 'task2', description: 'desc2', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id },
+              { content: 'task1', description: 'desc1', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id, status: status.first.id},
+              { content: 'task2', description: 'desc2', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id, status: status.first.id},
             ])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,14 +16,9 @@ projects = Project.create!([
                ])
 
 status = State.create!([
-                 { name: 'todo'},
-                 { name: 'done'},
-                 { name: 'appoint'},
-                 { name: 'wait'},
-                 { name: 'someday'},
-                 { name: 'cancel'},
-                 { name: 'inbox'},
-                 { name: 'draft'},
+                 { name: 'todo', priority: 1, color: "red", about:"やるべき Task"},
+                 { name: 'done', priority: 0, color: "black", about:"完了した Task"},
+                 { name: 'draft', priority: 2, color: "glay", about:"書きかけの Task"},
                 ])
 
 Task.create!([

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -26,14 +26,14 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
   test "should create task" do
     log_in_as(@user)
     assert_difference('Task.count') do
-    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, project_id: @task.project_id} }
+    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, project_id: @task.project_id, status: @task.status} }
     end
 
     assert_redirected_to tasks_url
   end
 
   test "should redirect create to login" do
-    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description} }
+    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, status: @task.status} }
     assert_redirected_to login_path
   end
 
@@ -50,7 +50,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
   test "should update task" do
     log_in_as(@user)
-    patch task_url(@task), params: { task: { content: @task.content, creator_id: @task.creator_id } }
+    patch task_url(@task), params: { task: { content: @task.content, creator_id: @task.creator_id} }
     assert_redirected_to tasks_url
   end
 

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -3,15 +3,17 @@
 one:
   content: MyText
   creator_id: 1
-  assigner_id : 1
-  due_at : 2021-07-16 12:22:22
+  assigner_id: 1
+  due_at: 2021-07-16 12:22:22
   description: test
-  project_id : 1
+  project_id: 1
+  status: 1
 
 two:
   content: MyText
   creator_id: 2
-  assigner_id : 1
-  due_at : 2021-07-16 12:22:22
+  assigner_id: 1
+  due_at: 2021-07-16 12:22:22
   description: test
-  project_id : 2
+  project_id: 2
+  status: 2

--- a/test/models/state_test.rb
+++ b/test/models/state_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StateTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#5 に対するPR

# やったこと
## 概要
- タスクの状態を表す state モデルを実装
- `db/seed.rb` に state モデルに入るデータを列挙
- タスクに status カラムを追加し，タスクの状態を設定できるように変更
- タスクの詳細画面で status を表示するように変更

## state モデルの内容
|カラム名|型|備考|
----|----|----
|id|int|データのid|
|name|string|状態名|

## seed.rb の state データの内容
|状態名|説明|
----|----
|todo|やるべきこと|
|done|完了|
|appoint|返事待ち|
|wait|中断|
|someday|いつかやること|
|cancel|中止|
|inbox|その他|
|draft|下書き|
