### PR TITLE
Add task_state model

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
 
   # GET /tasks or /tasks.json
   def index
-    @tasks = Task.all.includes(:user)
+    @tasks = Task.all.includes(:user, :state)
   end
 
   # GET /tasks/1 or /tasks/1.json
@@ -17,6 +17,7 @@ class TasksController < ApplicationController
     @task = Task.new
     @users = User.all
     @projects = Project.all
+    @task_states = TaskState.all
 
     project_id = params[:project_id]
     unless project_id.nil?
@@ -28,6 +29,7 @@ class TasksController < ApplicationController
   def edit
     @users = User.all
     @projects = Project.all
+    @task_states = TaskState.all
   end
 
   # POST /tasks or /tasks.json
@@ -70,6 +72,6 @@ class TasksController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def task_params
-    params.require(:task).permit(:assigner_id, :due_at, :content, :description, :project_id)
+    params.require(:task).permit(:assigner_id, :due_at, :content, :description, :project_id, :task_state_id)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ApplicationRecord
   belongs_to :user, foreign_key: 'creator_id'
   belongs_to :assigner, foreign_key: 'assigner_id', class_name: 'User'
   belongs_to :project, optional: true
+  belongs_to :state, foreign_key: 'task_state_id', class_name: 'TaskState'
 
   def show_days_ago
     day = ((self.created_at - Time.zone.now)/60/60/24).abs.round.to_s

--- a/app/models/task_state.rb
+++ b/app/models/task_state.rb
@@ -1,0 +1,2 @@
+class TaskState < ApplicationRecord
+end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -27,6 +27,11 @@
   </div>
 
   <div class="field my-4">
+    <%= form.label :due_at, "状態", class: "text-xl block font-bold mb-2" %>
+    <%= form.select :task_state_id, @task_states.map { |p| [p.name, p.id] }, { include_blank: false }, class: "border-2 w-full"  %>
+  </div>
+
+  <div class="field my-4">
     <%= form.label :content, "内容", class: "text-xl block font-bold mb-2" %>
     <%= form.text_field :content, class: "border-2 w-full", placeholder: "タスクの内容を入力してください", required: true %>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -13,6 +13,7 @@
         <p>所属プロジェクト: <%= link_to task.project.name, task.project %></p>
       <% end %>
       <p><%= task.show_days_ago %></p>
+      <P>状態: <%= task.state.name %></P>
     </div>
     <div class="flex-1"></div>
     <% if logged_in? %>

--- a/db/migrate/20211107082102_create_task_states.rb
+++ b/db/migrate/20211107082102_create_task_states.rb
@@ -1,0 +1,11 @@
+class CreateTaskStates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :task_states do |t|
+      t.string :name
+      t.integer :priority
+      t.string :about
+      t.string :color
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211107082503_add_state_id_to_tasks.rb
+++ b/db/migrate/20211107082503_add_state_id_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStateIdToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :tasks, :task_state, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_04_050454) do
+ActiveRecord::Schema.define(version: 2021_11_07_082503) do
 
   create_table "api_tokens", force: :cascade do |t|
     t.string "secret"
@@ -29,6 +29,15 @@ ActiveRecord::Schema.define(version: 2021_09_04_050454) do
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
+  create_table "task_states", force: :cascade do |t|
+    t.string "name"
+    t.integer "priority"
+    t.string "about"
+    t.string "color"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.text "content", null: false
     t.integer "creator_id"
@@ -38,7 +47,9 @@ ActiveRecord::Schema.define(version: 2021_09_04_050454) do
     t.integer "project_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "task_state_id"
     t.index ["project_id"], name: "index_tasks_on_project_id"
+    t.index ["task_state_id"], name: "index_tasks_on_task_state_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -58,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_09_04_050454) do
   add_foreign_key "projects", "users", on_delete: :cascade
   add_foreign_key "tasks", "projects"
   add_foreign_key "tasks", "projects", on_delete: :cascade
+  add_foreign_key "tasks", "task_states"
   add_foreign_key "tasks", "users", column: "assigner_id", on_delete: :cascade
   add_foreign_key "tasks", "users", column: "creator_id", on_delete: :cascade
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,18 +5,23 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+task_states = TaskState.create!([
+                                  { name: 'todo', priority: 1, color: "red", about:"やるべき Task"},
+                                  { name: 'done', priority: 0, color: "black", about:"完了した Task"},
+                                  { name: 'draft', priority: 2, color: "gray", about:"書きかけの Task"},
+                                ])
+
 users = User.create!([
-                      { name: 'user1', email: 'example@example.com', password: User.digest('password') },
-                      { name: 'user2', email: 'example2@example.com', password: User.digest('password') }
-                    ])
+                       { name: 'user1' },
+                       { name: 'user2' }
+                     ])
 
 projects = Project.create!([
-                 { name: 'project1', user_id: users.first.id },
-                 { name: 'project2', user_id: users.first.id }
-               ])
-
+                             { name: 'project1', user_id: users.first.id },
+                             { name: 'project2', user_id: users.first.id }
+                           ])
 
 Task.create!([
-              { content: 'task1', description: 'desc1', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id },
-              { content: 'task2', description: 'desc2', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id },
-            ])
+               { content: 'task1', description: 'desc1', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id, task_state_id: task_states.first.id },
+               { content: 'task2', description: 'desc2', due_at: '2021-07-16 12:22:22', creator_id: users.first.id, assigner_id: users.first.id, project_id: projects.first.id, task_state_id: task_states.first.id },
+             ])

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -27,7 +27,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
   test "should create task" do
     log_in_as(@user)
     assert_difference('Task.count') do
-    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, project_id: @task.project_id} }
+    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, project_id: @task.project_id, task_state_id: @task.task_state_id} }
     end
 
     assert_redirected_to tasks_url
@@ -51,7 +51,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
   test "should update task" do
     log_in_as(@user)
-    patch task_url(@task), params: { task: { content: @task.content, creator_id: @task.creator_id } }
+    patch task_url(@task), params: { task: { content: @task.content, creator_id: @task.creator_id, task_state_id: @task.task_state_id } }
     assert_redirected_to tasks_url
   end
 

--- a/test/fixtures/task_states.yml
+++ b/test/fixtures/task_states.yml
@@ -1,0 +1,10 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  id: 1
+  name: 'todo'
+

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -7,6 +7,7 @@ one:
   due_at : 2021-07-16 12:22:22
   description: test
   project_id : 1
+  task_state_id: 1
 
 two:
   content: MyText
@@ -15,3 +16,4 @@ two:
   due_at : 2021-07-16 12:22:22
   description: test
   project_id : 2
+  task_state_id: 1

--- a/test/models/task_state_test.rb
+++ b/test/models/task_state_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TaskStateTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
作業内容
- タスクの状態を管理するためのテーブルの追加
- ↑を保持するためのカラムを `tasks` テーブルに追加
- 上記の変更に伴うタスクの編集ページ及び一覧ページの変更
- テストの修正
