### PR TITLE
Add link

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -33,6 +33,7 @@ class DocumentsController < ApplicationController
   # POST /documents or /documents.json
   def create
     @document = current_user.documents.build(document_params)
+    @document.update(description: Document.add_unique_action_item_marker(@document[:description]))
 
     if @document.save #XXX: save! => save
       flash[:success] = "文書を追加しました"
@@ -44,6 +45,9 @@ class DocumentsController < ApplicationController
 
   # PATCH/PUT /documents/1 or /documents/1.json
   def update
+
+    @document.update(description: Document.add_unique_action_item_marker(@document[:description]))
+
     if @document.update(document_params)
       flash[:success] = "文書を更新しました"
       redirect_to documents_path

--- a/app/helpers/action_items_helper.rb
+++ b/app/helpers/action_items_helper.rb
@@ -1,0 +1,2 @@
+module ActionItemsHelper
+end

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,0 +1,13 @@
+class ActionItem < ApplicationRecord
+  after_create :set_uid
+
+  def uid
+    "%04d" % self.id
+  end
+
+    private
+
+  def set_uid
+    self.update(uid: uid)
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,4 +8,40 @@ class Document < ApplicationRecord
   validates :end_at, presence: true
   validates :location, presence: true
   #validates :project, presence: true
+  # Replace action-item number into corresponding GitHub issue number.
+  # Example:
+  #   "-->(name !:0001)" becomes "-->(name nomlab/jay/#10)"
+  def self.cooked_content(description)
+    new_description = ""
+    description.split("\n").map do |line|
+      line.gsub(/-->\((.+?)!:([0-9]{4})\)/) do |match|
+        assignee, action = $1.strip, $2
+        issue = ActionItem.find_by_id(action.to_i).try(:github_issue)
+        issue ? "-->(#{assignee} #{issue}{:data-action-item=\"#{action}\"})" :
+          "-->(#{assignee} !:#{action})"
+        line = line.gsub(/-->\((.+?)(?:!:([0-9]{4}))?\)/,  "-->(#{assignee} !:#{issue}{:data-action-item=\"#{action}\"})")
+      end
+      new_description += line
+      new_description += "\n"
+    end
+    return new_description
+  end
+
+  # Add action-item number with prefix "!:".
+  # Example:
+  #   "-->(name)" becomes "-->(name !:0001)"
+  def self.add_unique_action_item_marker(content)
+    new_description = ""
+    description = content.split("\n").map do |line|
+      line.gsub(/-->\((.+?)(?:!:([0-9]{4}))?\)/) do |match|
+        assignee, action = $1.strip, $2
+        action = ActionItem.create.uid unless action
+        "-->(#{assignee} !:#{action})"
+        line = line.gsub(/-->\((.+?)(?:!:([0-9]{4}))?\)/,  "-->(#{assignee} !:#{action})")
+      end
+      new_description += line
+      new_description += "\n"
+    end
+    return new_description
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
   resources :tags
+  resources :action_items
   resources :api_tokens
   resources :projects
   resources :tasks

--- a/db/migrate/20211119024205_create_action_items.rb
+++ b/db/migrate/20211119024205_create_action_items.rb
@@ -1,0 +1,12 @@
+class CreateActionItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :action_items do |t|
+      t.string :summary
+      t.string :uid
+      t.string :url
+
+      t.timestamps null: false
+    end
+    add_index :action_items, :url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_07_082503) do
+ActiveRecord::Schema.define(version: 2021_11_19_024205) do
+
+  create_table "action_items", force: :cascade do |t|
+    t.string "summary"
+    t.string "uid"
+    t.string "url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["url"], name: "index_action_items_on_url", unique: true
+  end
 
   create_table "api_tokens", force: :cascade do |t|
     t.string "secret"

--- a/test/controllers/action_items_controller_test.rb
+++ b/test/controllers/action_items_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ActionItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @action_item = action_items(:one)
+  end
+
+  test "should get index" do
+    get action_items_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_action_item_url
+    assert_response :success
+  end
+
+  test "should create action_item" do
+    assert_difference('ActionItem.count') do
+      post action_items_url, params: { action_item: { summary: @action_item.summary, uid: @action_item.uid, url: @action_item.url } }
+    end
+
+    assert_redirected_to action_item_url(ActionItem.last)
+  end
+
+  test "should show action_item" do
+    get action_item_url(@action_item)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_action_item_url(@action_item)
+    assert_response :success
+  end
+
+  test "should update action_item" do
+    patch action_item_url(@action_item), params: { action_item: { summary: @action_item.summary, uid: @action_item.uid, url: @action_item.url } }
+    assert_redirected_to action_item_url(@action_item)
+  end
+
+  test "should destroy action_item" do
+    assert_difference('ActionItem.count', -1) do
+      delete action_item_url(@action_item)
+    end
+
+    assert_redirected_to action_items_url
+  end
+end

--- a/test/fixtures/action_items.yml
+++ b/test/fixtures/action_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  summary: MyString
+  uid: MyString
+  url: MyString
+
+two:
+  summary: MyString
+  uid: MyString
+  url: MyString

--- a/test/models/action_item_test.rb
+++ b/test/models/action_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ActionItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/action_items_test.rb
+++ b/test/system/action_items_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class ActionItemsTest < ApplicationSystemTestCase
+  setup do
+    @action_item = action_items(:one)
+  end
+
+  test "visiting the index" do
+    visit action_items_url
+    assert_selector "h1", text: "Action Items"
+  end
+
+  test "creating a Action item" do
+    visit action_items_url
+    click_on "New Action Item"
+
+    fill_in "Summary", with: @action_item.summary
+    fill_in "Uid", with: @action_item.uid
+    fill_in "Url", with: @action_item.url
+    click_on "Create Action item"
+
+    assert_text "Action item was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Action item" do
+    visit action_items_url
+    click_on "Edit", match: :first
+
+    fill_in "Summary", with: @action_item.summary
+    fill_in "Uid", with: @action_item.uid
+    fill_in "Url", with: @action_item.url
+    click_on "Update Action item"
+
+    assert_text "Action item was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Action item" do
+    visit action_items_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Action item was successfully destroyed"
+  end
+end


### PR DESCRIPTION
### 概要
Jay の宿題記法を Rask に移植する．

Rask で文書を作成する際，
「XXX -->(氏名)」
という文章がある場合は「XXX -->(氏名 !:xxxx)」(xxxx は4桁の数字で表すUID)に変更し，GitHub Issue へのリンクを貼ることができるようにする．
また，上記のような記法を参考にし，Rask のタスクページへのリンクも貼ることができるようにする．

### やったこと
以下のカラムを持つActionItem テーブルを作成した．
|  カラム名  |  型  | 内容 |
| ---- | ---- | ---- |
|  summary |  string  | リンクの概要(予定)|
|  uid  |  string  | 固有の番号 |
| url | string | URL |

また，文書作成時で「XXX -->(氏名)」のような文章がある場合は，
「XXX -->(氏名 !:xxxx)」(xxxx は4桁の数字で表すUID)に内容を変更できるようにした．

### 今後の方針
+ タスクページへのリンクを貼るための記法の検討
+ javascript を用いてリンクを貼るプログラムの作成