### PR TITLE
Add jay css

### DIFF
--- a/app/assets/stylesheets/jay.scss
+++ b/app/assets/stylesheets/jay.scss
@@ -1,0 +1,153 @@
+body {
+	background-color: #fff;
+	color: #333;
+	font-family: verdana, arial, helvetica, sans-serif;
+	font-size: 13px;
+	line-height: 18px;
+	padding-top: 70px;
+	padding-bottom: 70px;
+}
+
+.avatar {
+	border: 0 none;
+	box-sizing: border-box;
+	background-color: #fff;
+	border-radius: 3px;
+	float: left;
+	line-height: 0;
+	margin-right: 0.6em;
+	vertical-align: baseline;
+}
+
+.navbar-nav li a {
+	line-height: 20px;
+}
+
+.navbar-header button {
+	margin: 10px 0px 0px 10px;
+}
+
+.navbar-header a {
+	margin: 0px 0px 0px 0px;
+	padding: 0px;
+}
+
+.navbar-header a img {
+	margin: 10px 0px 0px 10px;
+	padding: 0px;
+}
+
+textarea {
+	width: 100%;
+	font-family: monospace !important;
+}
+
+li.bullet-list-item {
+	list-style: outside none;
+	margin-left: 0px;
+	text-indent: -2.4em;
+}
+
+ul > li {
+	margin-left: 0px;
+	text-indent: 0em;
+}
+
+.bullet-list-marker {
+	font-family: monospace !important;
+	font-weight: normal;
+	/* margin-right: 0.5em; */
+	float: left;
+	width: 2em;
+	font-size: 120%;
+	color: #191970;
+}
+
+.markdown-body {
+	/* border: 1px solid #000000; */
+	background-color: #fafafa;
+	margin: 10px;
+	padding: 30px;
+	min-height: 20em;
+}
+
+.markdown-body > ul {
+	margin-left: 1em;
+}
+
+p,
+ol,
+ul,
+td {
+	font-family: verdana, arial, helvetica, sans-serif;
+	font-size: 13px;
+	line-height: 18px;
+}
+
+pre {
+	background-color: #eee;
+	padding: 10px;
+	font-size: 11px;
+}
+
+a {
+	color: #000;
+	&:visited {
+		color: #666;
+	}
+	&:hover {
+		color: #fff;
+		background-color: #000;
+	}
+}
+
+div {
+	&.field,
+	&.actions {
+		margin-bottom: 10px;
+	}
+}
+
+#notice {
+	color: green;
+}
+
+.field_with_errors {
+	padding: 2px;
+	background-color: red;
+	display: table;
+}
+
+#error_explanation {
+	width: 450px;
+	border: 2px solid red;
+	padding: 7px;
+	padding-bottom: 0;
+	margin-bottom: 20px;
+	background-color: #f0f0f0;
+	h2 {
+		text-align: left;
+		font-weight: bold;
+		padding: 5px 5px 5px 15px;
+		font-size: 12px;
+		margin: -7px;
+		margin-bottom: 0px;
+		background-color: #c00;
+		color: #fff;
+	}
+	ul li {
+		font-size: 12px;
+		list-style: square;
+	}
+}
+
+.marked {
+	background-color: #fff44f !important;
+}
+
+// 以降追記
+
+.prev_content > li {
+	display: list-item;
+	text-align: -webkit-match-parent;
+}

--- a/app/assets/stylesheets/jay.scss
+++ b/app/assets/stylesheets/jay.scss
@@ -147,7 +147,68 @@ div {
 
 // 以降追記
 
-.prev_content > li {
-	display: list-item;
-	text-align: -webkit-match-parent;
+.jay_document {
+	h1 {
+		display: block;
+		font-size: 2.25em;
+		font-weight: bold;
+		margin-block-start: 0.67em;
+		margin-block-end: 0.67em;
+		line-height: 1.2em;
+	}
+
+	h2 {
+		display: block;
+		font-size: 1.75em;
+		font-weight: bold;
+		margin-block-start: 0.83em;
+		margin-block-end: 0.83em;
+		line-height: 1em;
+	}
+
+	h3 {
+		display: block;
+		font-size: 1.5em;
+		font-weight: bold;
+		margin-block-start: 1em;
+		margin-block-end: 1em;
+		line-height: 1em;
+	}
+
+	h4 {
+		display: block;
+		font-size: 1.2em;
+		font-weight: bold;
+		margin-block-start: 1.33em;
+		margin-block-end: 1.33em;
+		line-height: 1em;
+	}
+
+	/* lists */
+
+	li {
+		display: list-item;
+		text-align: match-parent;
+	}
+
+	ul {
+		display: block;
+		list-style-type: disc;
+		margin-block-start: 1em;
+		margin-block-end: 1em;
+		padding-inline-start: 40px;
+	}
+
+	ul,
+	ol {
+		counter-reset: list-item;
+		margin: 1px;
+	}
+
+	ol {
+		display: block;
+		list-style-type: decimal;
+		padding-inline-start: 40px;
+		margin: 1px;
+	}
 }

--- a/app/assets/stylesheets/tab.css
+++ b/app/assets/stylesheets/tab.css
@@ -1,55 +1,54 @@
 /*タブ切り替え全体のスタイル*/
 .tabs {
-  margin-top: 50px;
-  padding-bottom: 40px;
-  background-color: #fff;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-  width: 700px;
-  margin: 0 auto;}
+	margin-top: 50px;
+	padding-bottom: 40px;
+	background-color: #fff;
+	box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+	width: 100%;
+	margin: 0 auto;
+}
 
 /*タブのスタイル*/
 .tab_item {
-  width: calc(100%/2);
-  height: 50px;
-  border-bottom: 3px solid #5ab4bd;
-  background-color: #d9d9d9;
-  line-height: 50px;
-  font-size: 16px;
-  text-align: center;
-  color: #565656;
-  display: block;
-  float: left;
-  text-align: center;
-  font-weight: bold;
-  transition: all 0.2s ease;
+	width: calc(100% / 2);
+	height: 50px;
+	border-bottom: 3px solid #5ab4bd;
+	background-color: #d9d9d9;
+	line-height: 50px;
+	font-size: 16px;
+	text-align: center;
+	color: #565656;
+	display: block;
+	float: left;
+	text-align: center;
+	font-weight: bold;
+	transition: all 0.2s ease;
 }
 .tab_item:hover {
-  opacity: 0.75;
+	opacity: 0.75;
 }
 
 /*ラジオボタンを全て消す*/
 input[name="tab_item"] {
-  display: none;
+	display: none;
 }
 
 /*タブ切り替えの中身のスタイル*/
 .tab_content {
-  display: none;
-  padding: 40px 40px 0;
-  clear: both;
-  overflow: hidden;
+	display: none;
+	padding: 40px 40px 0;
+	clear: both;
+	overflow: hidden;
 }
-
 
 /*選択されているタブのコンテンツのみを表示*/
 #write:checked ~ #write_content,
-#preview:checked ~ #preview_content
-{
-  display: block;
+#preview:checked ~ #preview_content {
+	display: block;
 }
 
 /*選択されているタブのスタイルを変える*/
 .tabs input:checked + .tab_item {
-  background-color: #5ab4bd;
-  color: #fff;
+	background-color: #5ab4bd;
+	color: #fff;
 }

--- a/app/javascript/stylesheets/tailwind.config.js
+++ b/app/javascript/stylesheets/tailwind.config.js
@@ -7,5 +7,7 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }

--- a/app/javascript/stylesheets/tailwind.config.js
+++ b/app/javascript/stylesheets/tailwind.config.js
@@ -7,7 +7,5 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
+  plugins: [],
 }

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -73,8 +73,10 @@
 	<%= form.text_area :description, class: "border-2 w-full", rows: 10, id: "write-area", placeholder: "文書内容を入力してください" %>
   </div>
   <div class="tab_content" id="preview_content">
-      <div id="preview-area" style="height: 300px" class="overflow-y-scroll">
-      </div>
+          <div style="height: 300px" class="overflow-y-scroll">
+           <div id="preview-area" class="p-12 prev_content">
+           </div>
+          </div>
 </div>
 </div>
 

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -74,7 +74,7 @@
   </div>
   <div class="tab_content" id="preview_content">
           <div style="height: 300px" class="overflow-y-scroll">
-           <div id="preview-area" class="p-12 prev_content">
+           <div id="preview-area" class="jay_document p-12 list-style-none">
            </div>
           </div>
 </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -10,6 +10,8 @@
   <p class="text-xl">所属プロジェクト:
     <%= link_to_if  @document.project&.name, @document.project&.name, @document.project %>
   <p class="text-xl block font-bold mb-2">文書内容</p>
-    <%== JayFlavoredMarkdownConverter.new(@document.description).content %>
+    <div class="jay_document">
+      <%== JayFlavoredMarkdownConverter.new(@document.description).content %>
+    </div>
   </p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag "application", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'tab' %>
+    <%= stylesheet_link_tag 'jay' %>
 
     <%# <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"> %>
 


### PR DESCRIPTION
Rask に登録した文書を表示する際に，jayと同じような表示になるように [jay で使用している css](https://github.com/nomlab/jay/blob/master/app/assets/stylesheets/scaffolds.scss) を編集して適用した．
文書の詳細画面にある文書内容の部分と，文書新規作成および文書編集時の preview 部分の表示を jay と同じような表示にした．