### PR TITLE
Update support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+log
+db/*.sqlite3
+storage
+.env
+config/master.key

--- a/scripts/docker/Dockerfile_production
+++ b/scripts/docker/Dockerfile_production
@@ -1,0 +1,54 @@
+# Dockerfile for Rask
+#   https://github.com/nomlab/rask
+#
+# Warning: This file is only for used by scripts/setup-docker.sh
+#          Do not create image from this Dockerfile manually
+
+FROM ruby:3.0.0
+
+ARG UID
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install required packages
+RUN curl https://deb.nodesource.com/setup_12.x | bash
+RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq \
+    && apt-get install -y locales sudo build-essential git-core vim libsqlite3-dev nodejs yarn \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN yarn add jquery
+RUN yarn add jquery-textcomplete
+
+# Set locale
+RUN locale-gen ja_JP.UTF-8
+ENV LANG ja_JP.UTF-8
+ENV LANGUAGE ja_JP:ja
+ENV LC_TIME C
+ENV TZ Asia/Tokyo
+RUN localedef -f UTF-8 -i ja_JP ja_JP.utf8
+
+# Add rask user
+RUN useradd -s /bin/bash -u $UID rask
+RUN usermod -aG sudo rask
+RUN sed -i 's/^%sudo.*$/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers
+
+# Copy app files from cwd
+RUN mkdir /home/rask
+WORKDIR /home/rask
+COPY . /home/rask
+
+RUN chown -R rask:rask /home/rask
+
+# Switch user to jay
+USER rask
+
+# Install gem
+RUN bundle config set path 'vendor/bundle'
+RUN bundle install
+RUN bundle exec rails webpacker:install
+RUN bundle exec rails tailwindcss:install
+
+# set cmd
+CMD ["./scripts/docker/docker-entrypoint.sh"]

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# This script is only for used by docker
+# Do not execute manually
+
+main() {
+    cd "$(dirname "$0")"
+    cd ../
+
+    # run rails server
+    export RAILS_SERVE_STATIC_FILES=true
+    bundle exec rails s -b 0.0.0.0 -p 3000 -e "production" &
+
+    # get pid of rails server
+    pid=$!
+
+    # stop server when receive SIGTERM
+    trap 'signal_handler $pid' SIGTERM
+
+    # wait for daemon stopping
+    wait
+}
+
+signal_handler() {
+    echo "Stopping process: pid=$1"
+    kill -2 $1
+}
+
+main

--- a/scripts/docker/docker-setup.sh
+++ b/scripts/docker/docker-setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This scirpt is only for used by scripts/setup-docker.sh
+# Do not execute manually
+
+if ! [ "$1" = "--skip-credentials" ];then
+    echo
+    echo "Creating master.key and credentials.yml.enc"
+    if ! EDITOR=":" bundle exec rails credentials:edit; then
+        echo
+        echo "Error:"
+        echo "    Failed to create master.key"
+        exit 1
+    fi
+fi
+
+echo
+echo "Migrating database"
+if ! bundle exec rails db:migrate; then
+    echo
+    echo "Error:"
+    echo "    Failed to migrate database"
+    exit 1
+fi
+
+echo
+echo "Compiling assets"
+if ! bundle exec rails assets:precompile RAILS_ENV="production"; then
+    echo
+    echo "Error:"
+    echo "    Failed to compile assets"
+    exit 1
+fi

--- a/scripts/rask-docker.sh
+++ b/scripts/rask-docker.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+#This script only works under below conditions
+# 1. Docker is installed
+
+# default value
+DEFAULT_ATTACH_OPTION=it # {i|t|it|d}
+DEFAULT_PORT=3000 # host port which container binds
+DEFAULT_COMMAND="" # command which execute in container
+                   # using default entrypoint of image, specify ""
+
+# constant value
+IMAGE_NAME=rask
+CONTAINER_NAME=rask
+SCRIPT_NAME=rask-docker.sh
+
+function print_usage(){
+    cat <<_EOT_
+$SCRIPT_NAME
+
+Usage:
+    $SCRIPT_NAME SubCommand
+
+Description:
+    start and stop $IMAGE_NAME on container
+
+SubCommands:
+    start    start $IMAGE_NAME container
+             for more details, run '$SCRIPT_NAME start -h'
+    stop     stop $IMAGE_NAME container
+    status   show conditions of $IMAGE_NAME container
+    restart  restart $IMAGE_NAME container
+    help     show this usage
+_EOT_
+}
+
+function print_start_usage(){
+    cat <<_EOT_
+Usage:
+    $SCRIPT_NAME start [OPTION] [COMMAND]
+
+Description:
+    run $IMAGE_NAME container
+    if COMMAND is specified, run COMMAND instead of dafault entrypoint
+
+Options:
+    -a         attach: connect tty to container
+    -d         dettach: input and output is discarded
+                        This option overrides -a option
+    -p number  port: bind 'number' port (default $PORT)
+    -h         help: show this usage
+_EOT_
+}
+
+function main(){
+    if ! user_belongs_dockergroup; then
+        echo "$(whoami) must belong 'docker' group"
+        exit 1
+    fi
+
+    cd "$(dirname "$0")"
+    cd ..
+
+    subcommand=$1
+    shift
+
+    case $subcommand in
+        start)
+            start $@
+            ;;
+        stop)
+            stop
+            ;;
+        status)
+            status
+            ;;
+        restart)
+            restart $@
+            ;;
+        help)
+            print_usage
+            ;;
+        "")
+            print_usage
+            ;;
+        *)
+            echo "Invalid option: '$1'"
+            exit 1
+            ;;
+    esac
+    return 0
+}
+
+function start(){
+    PORT=$DEFAULT_PORT
+    COMMAND=$DEFAULT_COMMAND
+    ATTACH_OPTION=$DEFAULT_ATTACH_OPTION
+    set_start_options $@
+
+    if container_is_running $CONTAINER_NAME; then
+        echo "$CONTAINER_NAME is already runnning"
+        exit 1
+    fi
+
+    if ! image_exists; then
+        echo "docker image not found: $IMAGE_NAME"
+        echo "build container image from Dockerfile"
+        exit 1
+    fi
+
+    if (! istty) && [ $ATTACH_OPTION = it ]; then
+        ATTACH_OPTION=i
+    fi
+
+    if port_is_used; then
+        echo "Port $PORT is already used"
+        exit 1
+    fi
+
+    echo "starting $CONTAINER_NAME"
+    docker run \
+        -$ATTACH_OPTION \
+        -p $PORT:3000 \
+        -v $PWD/log:/home/rask/log \
+        -v $PWD/storage:/home/rask/storage \
+        -v $PWD/public:/home/rask/public \
+        -v $PWD/config:/home/rask/config \
+        -v $PWD/db/production.sqlite3:/home/rask/db/production.sqlite3 \
+        -v $PWD/.env:/home/rask/.env \
+        --rm \
+        --name $CONTAINER_NAME \
+        $IMAGE_NAME $COMMAND
+}
+
+function set_start_options(){
+    while getopts dhop: OPT; do
+        case $OPT in
+            a)
+                ATTACH_OPTION=it
+                ;;
+            d)
+                ATTACH_OPTION=d
+                ;;
+            h)
+                print_start_usage
+                exit 0
+                ;;
+            p)
+                PORT=$OPTARG
+                ;;
+            *)
+                echo "Invalid option: $OPT"
+                exit 1
+                ;;
+        esac
+    done
+    COMMAND=${@:$OPTIND}
+}
+
+function stop(){
+    if ! container_is_running; then
+        echo "$CONTAINER_NAME is not running"
+        exit 1
+    fi
+
+    echo -n "trying to stop $CONTAINER_NAME... "
+    docker stop $CONTAINER_NAME > /dev/null && \
+        echo "done."
+}
+
+function status(){
+    if container_is_running; then
+        echo "$CONTAINER_NAME is running"
+    else
+        echo "$CONTAINER_NAME is not running"
+    fi
+}
+
+function restart(){
+    stop
+    start $@
+}
+
+function user_belongs_dockergroup(){
+    if [ $(groups | grep -c -e docker -e root) = 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function container_is_running(){
+    if [ $(docker ps -a --format "table {{.Names}}" |grep -cx "$CONTAINER_NAME") = 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function image_exists(){
+    if [ $(docker images $IMAGE_NAME | wc -l) = 1 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function istty(){
+    if tty -s; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function port_is_used(){
+    if [ $(ss -antu | grep -c ":$PORT ") != 0 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+main "$@"

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# This scripts is for setting up rask image
+# * Create rask image
+# * Create master.key and credential.yml.enc
+# * Migrate database for production
+# * Compile assets
+
+function usage() {
+    cat <<_EOT_
+Description:
+    Setup Rask container
+
+Note:
+    This script is only for production environment.
+    If you want to use development environment, build image with 'rask/Dockerfile'
+
+Usage:
+    setup-docker.sh <UserName>
+    <UserName> : name of user that runs rask container.
+_EOT_
+}
+
+function main() {
+    cd $(dirname $0)
+    cd ../
+
+    if [ "$1" = "" ]; then
+        usage
+        exit 1
+    fi
+
+    if ! user_exists $1; then
+        echo
+        echo "Error:"
+        echo "     Specified user does not exist"
+        exit 1
+    fi
+
+    if ! [ -e .env ]; then
+        echo
+        echo "Error:"
+        echo "    Not found: .env"
+        echo "Help:"
+        echo "    create .env from .env.sample"
+        exit 1
+    fi
+
+    if ! [ -e db/production.sqlite3 ]; then
+        echo
+        echo "Information:"
+        echo "    Not found: db/production.sqlite3"
+        echo "    create empty db/production.sqlite3"
+        touch db/production.sqlite3
+    fi
+
+    if (! [ -e config/master.key ]) && [ -e config/credentials.yml.enc ]; then
+            echo ""
+            echo "Error:"
+            echo "    'config/credentials.yml.enc' exists, but 'config/master.key' does not exist."
+            echo "Help:"
+            echo "    Bring master.key for current credentials.yml.enc or"
+            echo "    Delete credentials.yml.enc to create new pair"
+            exit 1
+    fi
+
+    if [ -e config/master.key ] && [ -e config/credentials.yml.enc ]; then
+        ARGS="--skip-credentials"
+    else
+        ARGS=""
+    fi
+
+    for i in $(seq 3000 10000); do
+        if [ $(ss -antu | grep -c ":$i ") = 0 ]; then
+            PORT=$i
+            break
+        fi
+    done
+
+    echo
+    echo "Creating Rask image"
+    UID_SH=$(id -u $1)
+    if ! docker build -t rask -f scripts/docker/Dockerfile_production --build-arg UID=$UID_SH .; then
+        echo
+        echo "Error:"
+        echo "    Failed to build docker image"
+        exit 1
+    fi
+
+    echo
+    echo "Setting up in container"
+    if ! scripts/rask-docker.sh start -p $PORT scripts/docker/docker-setup.sh $ARGS; then
+        echo
+        echo "Error:"
+        echo "    Failed to setup docker container"
+        exit 1
+    fi
+
+    echo "Done."
+}
+
+function user_exists() {
+    if id -u $1 > /dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+main $1

--- a/scripts/systemd_conf/rask.service
+++ b/scripts/systemd_conf/rask.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Rask: Task Management System
+Requires=docker.service
+After=docker.service
+
+[Service]
+# Change path to suit your environment
+WorkingDirectory=<Path to rask repository>
+ExecStart=<Path to rask repository>/scripts/rask-docker.sh start -p 3000
+ExecStop=<Path to rask repository>/scripts/rask-docker.sh stop
+
+# Change user who owns this repository
+User=rask
+
+Type=simple
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## やったこと
production 環境をセットアップ，運用するためのスクリプトを追加した．
また，Rask を systemd から管理できるようにした．

## 変更点
1. scripts/setup-docker.sh を追加
    production 環境用の Docker のイメージを作成するスクリプト
2. scripts/rask-docker.sh を追加
    Docker を用いて Rask を起動，停止するためのスクリプト
3. scripts/docker/* を追加
    1 のスクリプトが使用するファイルをまとめたディレクトリ
4. scripts/systemd_conf/rask.service を追加
    Rask を systemd で起動するための service ファイル

# 使用例
1.  イメージの作成
    ```scripts/setup-docker.sh rask_user```
2. Rask の起動
    ```scripts/rask-docker.sh start```
3. Rask の停止
    ```scripts/rask-docker.sh stop```