### PR TITLE
Update to build multi containers

### DIFF
--- a/scripts/rask-docker.sh
+++ b/scripts/rask-docker.sh
@@ -11,7 +11,6 @@ DEFAULT_COMMAND="" # command which execute in container
 
 # constant value
 IMAGE_NAME=rask
-CONTAINER_NAME=rask
 SCRIPT_NAME=rask-docker.sh
 
 function print_usage(){
@@ -28,8 +27,10 @@ SubCommands:
     start    start $IMAGE_NAME container
              for more details, run '$SCRIPT_NAME start -h'
     stop     stop $IMAGE_NAME container
+             for more details, run '$SCRIPT_NAME stop -h'
     status   show conditions of $IMAGE_NAME container
     restart  restart $IMAGE_NAME container
+             for more details, run '$SCRIPT_NAME restart -h'
     help     show this usage
 _EOT_
 }
@@ -52,6 +53,30 @@ Options:
 _EOT_
 }
 
+function print_stop_usage(){
+    cat <<_EOT_
+Usage:
+    $SCRIPT_NAME stop [CONTAINER]
+
+Description:
+    stop $IMAGE_NAME container
+    if CONTAINER is specified, stop CONTAINER
+    if CONTAINER is not specified, stop $IMAGE_NAME-$DEFAULT_PORT if only $IMAGE_NAME-$DEFAULT_PORT is running
+_EOT_
+}
+
+function print_restart_usage(){
+    cat <<_EOT_
+Usage:
+    $SCRIPT_NAME restart [CONTAINER]
+
+Description:
+    restart $IMAGE_NAME container
+    if CONTAINER is specified, restart CONTAINER
+    if CONTAINER is not specified, restart $IMAGE_NAME-$DEFAULT_PORT if only $IMAGE_NAME-$DEFAULT_PORT is running
+_EOT_
+}
+
 function main(){
     if ! user_belongs_dockergroup; then
         echo "$(whoami) must belong 'docker' group"
@@ -69,7 +94,7 @@ function main(){
             start $@
             ;;
         stop)
-            stop
+            stop $@
             ;;
         status)
             status
@@ -96,6 +121,7 @@ function start(){
     COMMAND=$DEFAULT_COMMAND
     ATTACH_OPTION=$DEFAULT_ATTACH_OPTION
     set_start_options $@
+    CONTAINER_NAME="${IMAGE_NAME}-${PORT}"
 
     if container_is_running $CONTAINER_NAME; then
         echo "$CONTAINER_NAME is already runnning"
@@ -118,22 +144,26 @@ function start(){
     fi
 
     echo "starting $CONTAINER_NAME"
-    docker run \
-        -$ATTACH_OPTION \
-        -p $PORT:3000 \
-        -v $PWD/log:/home/rask/log \
-        -v $PWD/storage:/home/rask/storage \
-        -v $PWD/public:/home/rask/public \
-        -v $PWD/config:/home/rask/config \
-        -v $PWD/db/production.sqlite3:/home/rask/db/production.sqlite3 \
-        -v $PWD/.env:/home/rask/.env \
-        --rm \
-        --name $CONTAINER_NAME \
-        $IMAGE_NAME $COMMAND
+
+    if container_is_stopped $CONTAINER_NAME; then    
+        docker start $CONTAINER_NAME > /dev/null
+    else
+        docker run \
+            -$ATTACH_OPTION \
+            -p $PORT:3000 \
+            -v $PWD/log:/home/rask/log \
+            -v $PWD/storage:/home/rask/storage \
+            -v $PWD/public:/home/rask/public \
+            -v $PWD/config:/home/rask/config \
+            -v $PWD/db/production.sqlite3:/home/rask/db/production.sqlite3 \
+            -v $PWD/.env:/home/rask/.env \
+            --name $CONTAINER_NAME \
+            $IMAGE_NAME $COMMAND
+    fi
 }
 
 function set_start_options(){
-    while getopts dhop: OPT; do
+    while getopts dhap: OPT; do
         case $OPT in
             a)
                 ATTACH_OPTION=it
@@ -158,27 +188,98 @@ function set_start_options(){
 }
 
 function stop(){
-    if ! container_is_running; then
+    set_stop_options $@
+    if [ $# -eq 0 ]; then
+        if only_default_running; then
+            CONTAINER_NAME="${IMAGE_NAME}-${DEFAULT_PORT}"
+        else
+            echo "${IMAGE_NAME}-${DEFAULT_PORT} is not running or other $IMAGE_NAME container is running."
+            print_stop_usage
+            exit 1
+        fi
+    fi
+
+    if ! container_is_running $CONTAINER_NAME; then
         echo "$CONTAINER_NAME is not running"
         exit 1
     fi
 
     echo -n "trying to stop $CONTAINER_NAME... "
     docker stop $CONTAINER_NAME > /dev/null && \
+    docker rm $CONTAINER_NAME > /dev/null && \
         echo "done."
 }
 
+function set_stop_options(){
+    while getopts h OPT; do
+        case $OPT in
+            h)
+                print_stop_usage
+                exit 0
+                ;;
+            *)
+                echo "Invalid option: $OPT"
+                exit 1
+                ;;
+        esac
+    done
+    CONTAINER_NAME=${@:$OPTIND}
+}
+
 function status(){
-    if container_is_running; then
-        echo "$CONTAINER_NAME is running"
+    if ! count_running_container $IMAGE_NAME; then
+        echo "Running container(s):"
+        list_running_container $IMAGE_NAME
     else
-        echo "$CONTAINER_NAME is not running"
+       echo "Container is not running"
     fi
 }
 
 function restart(){
-    stop
-    start $@
+    set_restart_options $@
+    if [ $# -eq 0 ]; then
+        if only_default_running; then
+            CONTAINER_NAME="${IMAGE_NAME}-${DEFAULT_PORT}"
+        else
+            echo "${IMAGE_NAME}-${DEFAULT_PORT} is not running or other $IMAGE_NAME container is running."
+            print_restart_usage
+            exit 1
+        fi
+    fi
+
+    if ! container_is_running $CONTAINER_NAME; then
+        echo "$CONTAINER_NAME is not running"
+        exit 1
+    fi
+
+    echo -n "trying to restart $CONTAINER_NAME... "
+    docker restart $CONTAINER_NAME > /dev/null && \
+        echo "done."
+}
+
+function set_restart_options(){
+    while getopts h OPT; do
+        case $OPT in
+            h)
+                print_restart_usage
+                exit 0
+                ;;
+            *)
+                echo "Invalid option: $OPT"
+                exit 1
+                ;;
+        esac
+    done
+    CONTAINER_NAME=${@:$OPTIND}
+}
+
+function only_default_running(){
+    count_running_container $IMAGE_NAME
+    if [ $? = 1 ]; then
+        return $(container_is_running "$IMAGE_NAME-$DEFAULT_PORT")
+    else
+        return 1
+    fi
 }
 
 function user_belongs_dockergroup(){
@@ -189,8 +290,24 @@ function user_belongs_dockergroup(){
     fi
 }
 
+function list_running_container(){
+    docker ps --format "table {{.Names}}" | grep $1
+}
+
+function count_running_container(){
+    return $(docker ps --format "table {{.Names}}" | grep -c $1)
+}
+
 function container_is_running(){
-    if [ $(docker ps -a --format "table {{.Names}}" |grep -cx "$CONTAINER_NAME") = 0 ]; then
+    if [ $(docker ps --format "table {{.Names}}" | grep -cx $1) = 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function container_is_stopped(){
+    if [ $(docker ps -f status=exited --format "table {{.Names}}" | grep -cx $1) = 0 ]; then
         return 1
     else
         return 0
@@ -214,7 +331,7 @@ function istty(){
 }
 
 function port_is_used(){
-    if [ $(ss -antu | grep -c ":$PORT ") != 0 ]; then
+    if [ $(lsof -i:$PORT | wc -l) != 0 ]; then
         return 0
     else
         return 1


### PR DESCRIPTION
## やったこと
2つ以上インスタンスを作成できるようにした．

## 変更点
1. コンテナ名にポート番号を含めた
2. start，stop，restart，status の動作を以下の利用例のように変更した
3. start の際に -rm オプションを指定せずに起動するように変更した
4. start の際に指定したコンテナの状態が STOPPED の場合，そのコンテナを起動するように変更した
5. stop の際に docker stop と docker rm を実行するように変更した

## 利用例
1. 複数コンテナの起動
```scripts/rask-docker.sh start```
```scripts/rask-docker.sh start -p 3030```
-p オプションでポートを指定して起動する．
引数がない場合， 3000 番で起動する． 

2. 起動中コンテナの確認
```scripts/rask-docker.sh status```
出力結果例：
```
Running container(s):
rask-3030
rask-3000
```

3. コンテナの停止
```scripts/rask-docker.sh stop rask-3000```
コンテナの名前を指定してコンテナを停止する．
指定されない場合，rask-3000 が停止する．
ただし，rask-3000 以外のコンテナが起動していた場合は停止しない．

4. コンテナの再起動
```scripts/rask-docker.sh restart rask-3030```
コンテナの名前を指定してコンテナを再起動する．
指定されない場合，rask-3000 が再起動する．
ただし，rask-3000 以外のコンテナが起動していた場合は再起動しない．