### PR TITLE
Add ActionItem

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,6 +19,7 @@ class TasksController < ApplicationController
     @projects = Project.all
     @tags = Tag.all
     @task_states = TaskState.all
+    @task.description = params[:desc_header]
 
     project_id = params[:project_id]
     unless project_id.nil?
@@ -41,6 +42,10 @@ class TasksController < ApplicationController
 
     if @task.save!
       flash[:success] = "タスクを追加しました"
+      matched = task_params[:description].match(/\[AI([0-9]+)\]/)
+      if matched != nil
+        ActionItem.find(matched[1]).update(task_url: tasks_path + "/" + @task.id.to_s)
+      end
       redirect_to tasks_path
     else
       redirect_back fallback_location: new_task_path

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,0 +1,13 @@
+class ActionItem < ApplicationRecord
+  after_create :set_uid
+
+  def uid
+    "%04d" % self.id
+  end
+
+  private
+
+  def set_uid
+    self.update(uid: uid)
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,4 +8,18 @@ class Document < ApplicationRecord
   validates :end_at, presence: true
   validates :location, presence: true
   #validates :project, presence: true
+  before_validation :add_unique_action_item_marker
+
+  def add_unique_action_item_marker
+    desc = ""
+    self.description.each_line {|line|
+      matched = line.match(/-->\((.+)\)/)
+      if matched != nil
+        @action_item = ActionItem.create(task_url: nil)
+        line.gsub!(/-->\(.+\)/, "-->(#{matched[1]} !#{@action_item.uid})")
+      end
+      desc += line
+    }
+    self.description = desc
+  end
 end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -10,8 +10,24 @@
   <p class="text-xl">所属プロジェクト:
     <%= link_to_if  @document.project&.name, @document.project&.name, @document.project %>
   <p class="text-xl block font-bold mb-2">文書内容</p>
-    <div class="jay_document">
-      <%== JayFlavoredMarkdownConverter.new(@document.description).content %>
+  <div class="jay_document">
+    <% desc = JayFlavoredMarkdownConverter.new(@document.description).content %>
+    <% desc.each_line do |line| %>
+      <% matched = line.match(/\([^ ]+ !([0-9]+)\)/) %>
+      <% if matched != nil %>
+        <%== $` %>
+        <% task_url = ActionItem.find_by(uid:matched[1].to_i).task_url %>
+        <% if task_url != nil %>
+          <%= link_to matched[0], task_url.to_s %>
+        <% else %>
+          <% message = "Created from [AI#{matched[1]}](#{request.url})" %>
+          <%= link_to matched[0], new_task_path(desc_header: message) %>
+        <% end %>
+        <%== $' %>
+      <% else %>
+        <%== line %>
+      <% end %>
+    <% end %>
     </div>
   </p>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -20,7 +20,16 @@
 
 <div class="my-3">
   <p class="text-xl block font-bold mb-2">説明</p>
-  <%= @task.description %>
+    <% @task.description.each_line do |line| %>
+      <% matched = line.match(/\((.+)\)/) %>
+      <% if matched != nil %>
+        <%== $` %>
+        <%= link_to matched[0], matched[1] %>
+        <%== $' %>
+      <% else %>
+        <%== line %>
+      <% end %>
+    <% end %>
 </div>
 
 <div class="my-3">

--- a/db/migrate/20221006041706_create_action_items.rb
+++ b/db/migrate/20221006041706_create_action_items.rb
@@ -1,0 +1,10 @@
+class CreateActionItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :action_items do |t|
+      t.integer :uid
+      t.string :task_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_07_082503) do
+ActiveRecord::Schema.define(version: 2022_10_06_041706) do
+
+  create_table "action_items", force: :cascade do |t|
+    t.integer "uid"
+    t.string "task_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "api_tokens", force: :cascade do |t|
     t.string "secret"
@@ -58,15 +65,6 @@ ActiveRecord::Schema.define(version: 2021_11_07_082503) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "task_tag_relations", force: :cascade do |t|
-    t.integer "task_id", null: false
-    t.integer "tag_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["tag_id"], name: "index_task_tag_relations_on_tag_id"
-    t.index ["task_id"], name: "index_task_tag_relations_on_task_id"
-  end
-
   create_table "task_tags", force: :cascade do |t|
     t.integer "task_id"
     t.integer "tag_id"
@@ -86,20 +84,10 @@ ActiveRecord::Schema.define(version: 2021_11_07_082503) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "tag_id"
-    t.index ["project_id"], name: "index_tasks_on_project_id"
-    t.index ["tag_id"], name: "index_tasks_on_tag_id"
     t.integer "task_state_id"
     t.index ["project_id"], name: "index_tasks_on_project_id"
+    t.index ["tag_id"], name: "index_tasks_on_tag_id"
     t.index ["task_state_id"], name: "index_tasks_on_task_state_id"
-  end
-
-  create_table "tasks_tags", force: :cascade do |t|
-    t.integer "task_id", null: false
-    t.integer "tag_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["tag_id"], name: "index_tasks_tags_on_tag_id"
-    t.index ["task_id"], name: "index_tasks_tags_on_task_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -121,14 +109,10 @@ ActiveRecord::Schema.define(version: 2021_11_07_082503) do
   add_foreign_key "documents", "users", column: "creator_id", on_delete: :cascade
   add_foreign_key "projects", "users"
   add_foreign_key "projects", "users", on_delete: :cascade
-  add_foreign_key "task_tag_relations", "tags"
-  add_foreign_key "task_tag_relations", "tasks"
   add_foreign_key "tasks", "projects"
   add_foreign_key "tasks", "projects", on_delete: :cascade
   add_foreign_key "tasks", "tags"
   add_foreign_key "tasks", "task_states"
   add_foreign_key "tasks", "users", column: "assigner_id", on_delete: :cascade
   add_foreign_key "tasks", "users", column: "creator_id", on_delete: :cascade
-  add_foreign_key "tasks_tags", "tags"
-  add_foreign_key "tasks_tags", "tasks"
 end

--- a/test/fixtures/action_items.yml
+++ b/test/fixtures/action_items.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  task_url: /1
+
+two:
+  task_url: /1

--- a/test/models/action_item_test.rb
+++ b/test/models/action_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ActionItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
Jay の宿題記法を Rask に移植した．

Rask で文書を作成する際，宿題記法が存在すれば，宿題記法にユニークな task_id (宿題記法をタスクを結びつける id) を追加しタスク作成のリンクを埋め込む．また，文書閲覧の際，宿題記法に対応するタスクが存在する場合はタスク詳細画面へのリンクを埋め込む．

宿題記法を用いた文書作成の例として，「新しい機能を付け足す．-->(向原)」という記述があれば「新しい機能を付け足す．-->(向原 !1)」のように宿題記法を書き換え，リンクを埋め込む．

### やったこと
+ ActionItem テーブルを追加した．

|  カラム名  |  型  |  内容  |
| ---- | ---- | ---- |
|  task_id  |  integer  |  ActionItem テーブルの主キーに対応する Task テーブルの主キー  |

+ 文書の controller の修正
文書作成の際，宿題記法が存在すれば ActionItem テーブルのレコードを作成し，その主キーを追加して宿題記法を上書きする．

+ 文書の view の修正
宿題記法が存在すると，宿題記法中の ActonItem の主キーを用いて対応するタスクの存在を確認し，存在すればタスク詳細画面へのリンク，存在しなければタスク作成画面へのリンクを埋め込む．後者の際，ActionItem の主キーを含む文字列をクエリパラメータとしてリンクに追加する．

+ タスクの controller の修正
クエリパラメータとして受け取った文字列を作成するタスクの description フィールド (タスクの説明) に埋め込む．タスクを作成する際に description フィールドに ActionItem の主キーが含まれている場合は，主キーに対応するレコードの task_id に作成したタスクの主キーを追加する．

