### PR TITLE
Fill in columns of task automatically

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,8 +16,10 @@ class TasksController < ApplicationController
   def new
     @task = Task.new
     @users = User.all
+    @assigner_id = params[:assigner_id]
     @projects = Project.all
     @tags = Tag.all
+    @task_title = params[:selected_str]
     @task_states = TaskState.all
     @task.description = params[:desc_header]
 

--- a/app/javascript/packs/documents.js
+++ b/app/javascript/packs/documents.js
@@ -1,0 +1,11 @@
+const anchor = document.querySelectorAll("div.jay_document a");
+
+anchor.forEach(function(el){
+    const new_task_url = el.getAttribute("href");
+    el.addEventListener('click', function(el){
+        el.preventDefault();
+        const selectedText = window.getSelection().toString();
+        window.location.href = new_task_url + "&selected_str=" + selectedText;
+    })
+})
+

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -21,15 +21,19 @@
   <div class="jay_document">
     <% desc = JayFlavoredMarkdownConverter.new(@document.description).content %>
     <% desc.each_line do |line| %>
-      <% matched = line.match(/\([^ ]+ !([0-9]+)\)/) %>
+      <% matched = line.match(/\(([^ ]+) !([0-9]+)\)/) %>
       <% if matched != nil %>
         <%== $` %>
-        <% task_url = ActionItem.find_by(uid:matched[1].to_i).task_url %>
+        <% task_url = ActionItem.find_by(uid:matched[2].to_i).task_url %>
+        <% assigner =  User.find_by(screen_name:matched[1].to_s) %>
         <% if task_url != nil %>
           <%= link_to matched[0], task_url.to_s %>
         <% else %>
-          <% message = "Created from [AI#{matched[1]}](#{request.url})" %>
-          <%= link_to matched[0], new_task_path(desc_header: message) %>
+          <% message = "Created from [AI#{matched[2]}](#{request.url})" %>
+          <% if assigner != nil %>
+            <% assigner_id =  assigner.id %>
+          <% end %>
+          <%= link_to matched[0], new_task_path(assigner_id: assigner_id, project_id: @document.project_id, desc_header: message) %>
         <% end %>
         <%== $' %>
       <% else %>
@@ -39,3 +43,4 @@
     </div>
   </p>
 </div>
+<%= javascript_pack_tag 'documents' %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -13,7 +13,7 @@
 
     <div class="field my-4">
     <%= form.label :assigner_id, "担当者", class: "text-xl block font-bold mb-2" %>
-    <%= form.select :assigner_id, @users.map { |u| [u.name, u.id] }, {}, class: "border-2 w-full" %>
+    <%= form.select :assigner_id, @users.map { |u| [u.screen_name, u.id] }, { selected: @assigner_id }, class: "border-2 w-full" %>
   </div>
 
   <div class="field my-4">
@@ -48,7 +48,7 @@
 
   <div class="field my-4">
     <%= form.label :content, "内容", class: "text-xl block font-bold mb-2" %>
-    <%= form.text_field :content, class: "border-2 w-full", placeholder: "タスクの内容を入力してください", required: true %>
+    <%= form.text_field :content, value: @task_title, class: "border-2 w-full", placeholder: "タスクの内容を入力してください", required: true %>
   </div>
 
   <div class="field my-4">


### PR DESCRIPTION
### 概要
宿題記法からタスクを作成する際，担当者，プロジェクト名，内容を自動で埋める．

担当者は宿題記法を指定した screen_name(存在しなければログインしているユーザの screen_name)，プロジェクト名は宿題記法がある文書のプロジェクト名，内容は宿題記法からタスク作成ページに遷移する際に範囲選択している文字列で埋める．

### 変更点
+ 文書の view の修正
宿題記法の URL を作成する際に，新たに担当者とプロジェクト名をクエリパラメータとして追加した．

+ js ファイルの追加
タスク作成時に範囲選択している文字列をクエリパラメータとして追加するために，[app/javascript/packs/minutes.js](https://github.com/mukohara/rask/commit/aa4c1404d2bd035e95597a96bd66e7b76160c295#diff-da5445f524139819789a5ee05793e3c4a55feeb2be9e1385a1399da2c6a3793c)を追加した．