### PR TITLE
Fix regular expression matching SHUKUDAI_NOTATION

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -16,7 +16,7 @@ class Document < ApplicationRecord
   def add_unique_action_item_marker
     desc = ""
     self.description.each_line {|line|
-      matched = line.match(/-->\((.+)\)/)
+      matched = line.match(/-->\(([^!]+)\)/)
       if matched != nil
         @action_item = ActionItem.create(task_url: nil)
         line.gsub!(/-->\(.+\)/, "-->(#{matched[1]} !#{@action_item.uid})")


### PR DESCRIPTION
## 概要
Issue #43 に対する PR

## 原因
宿題記法を探して，ActionItemを生成する処理において，
宿題記法にマッチさせる正規表現が，ActionItem生成後のリンク形式にもマッチしていた．
その結果，ActionItem生成後のリンク形式に対しても新たにActionItemを生成していた．

宿題記法: `-->(name)`
ActionItem生成後のリンク形式: `-->(name !dddd)`

## 解決方法
ActionItem生成後のリンク形式をマッチしないように正規表現を変更した．