### PR TITLE
Change documents in descending order by creation date

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,7 +5,7 @@ class DocumentsController < ApplicationController
   protect_from_forgery :except => [:api_markdown]
   # GET /documents or /documents.json
   def index
-    @documents = Document.all.includes(:user)
+    @documents = Document.all.includes(:user).order(start_at: "DESC")
   end
 
   # GET /documents/1 or /documents/1.json

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -8,7 +8,7 @@
   <div class="p-3 my-3 border rounded flex space-x-4">
     <div>
       <p class="text-xl"><%= document.content %></p>
-      <p>作成日: <%= document.created_at&.strftime('%Y/%m/%d') %></p>
+      <p>開始日: <%= document.start_at&.strftime('%Y/%m/%d') %></p>
       <p>場所: <%= document.location %></p>
       <p>作成者: <%= link_to_if document.assigner&.name, document.assigner&.name, document.assigner %></p>
     </div>


### PR DESCRIPTION
文書一覧で表示される文書が昇順で表示されるため，古い文書はページの上にあり，新しく作成した文書はページの下に表示される．
そこで，controllerを調整することで開始時刻の降順に表示されるように変更し，開始時刻が最近の文書はページの上に表示されるようにした．