### PR TITLE
Add task_url deletion process 

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -66,7 +66,8 @@ class TasksController < ApplicationController
   end
 
   # DELETE /tasks/1 or /tasks/1.json
-  def destroy
+  def destroy 
+    ActionItem.find_by(task_url: "/tasks/#{@task.id}").update(task_url: nil)
     @task.destroy
     respond_to do |format|
       format.html { redirect_to tasks_url, notice: "タスクを削除しました" }


### PR DESCRIPTION
## 概要
* issue #44 の修正
* 宿題記法から作成したタスクを削除すると，その記法に対応する ActionItem の task_url を削除する処理を追加した．
* タスク削除後に対応する宿題記法のリンク先に遷移すると，タスクの新規作成画面に遷移するようにした．