### PR TITLE
Update to enable search of documents and tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,6 @@ gem 'dotenv-rails'
 gem 'jay_flavored_markdown', git: 'https://github.com/nomlab/jay_flavored_markdown'
 
 gem 'kaminari'
+
+# use ransack for searching
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,10 @@ GEM
       rake (>= 0.13)
       thor (~> 1.0)
     rake (13.0.3)
+    ransack (3.1.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -320,6 +324,7 @@ DEPENDENCIES
   puma (~> 5.3)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
+  ransack
   rexml
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,6 +1,14 @@
 <div class="flex">
   <%= render 'layouts/h1', title: "文書一覧" %>
   <div class="flex-1"></div>
+  <%= link_to '全文書一覧へ', documents_path, class: "my-auto text-white bg-blue-400 rounded p-2" %>
+  <div class="p-3 my-3 border rounded flex space-x-4">
+  <!--検索フォーム-->
+  <%= search_form_for @q do |f| %>
+    <%= f.text_field :keyword_cont, placeholder: '検索ワードを入力してください' %>
+    <%= f.submit "検索" %>
+    <% end %>
+  </div>
   <%= link_to '新規作成', new_document_path, class: "my-auto text-white bg-red-400 rounded p-2" %>
 </div>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,14 @@
 <div class="flex">
   <%= render 'layouts/h1', title: "タスク一覧" %>
   <div class="flex-1"></div>
+  <%= link_to '全タスク一覧へ', tasks_path, class: "my-auto text-white bg-blue-400 rounded p-2" %>
+  <div class="p-3 my-3 border rounded flex space-x-4">
+  <!--検索フォーム-->
+  <%= search_form_for @q do |f| %>
+    <%= f.text_field :keyword_cont, placeholder: '検索ワードを入力してください' %>
+    <%= f.submit "検索" %>
+    <% end %>
+  </div>
   <%= link_to '新規作成', new_task_path, class: "my-auto text-white bg-red-400 rounded p-2" %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,19 @@ Rails.application.routes.draw do
   resources :tags
   resources :api_tokens
   resources :projects
-  resources :tasks
+  resources :tasks do
+    collection do
+      get 'search'
+    end
+  end
   resources :users
-  resources :documents
+  resources :documents do
+    collection do
+      get 'search'
+    end
+  end
   post '/documents/api_markdown', to: 'documents#api_markdown'
-  
+
   get '/', to: redirect('/projects')
 
   get '/auth/:provider/callback', to: 'sessions#create'

--- a/db/migrate/20221215022134_add_keyword_to_tasks.rb
+++ b/db/migrate/20221215022134_add_keyword_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddKeywordToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :keyword, :text
+  end
+end

--- a/db/migrate/20221219065934_add_keyword_to_documents.rb
+++ b/db/migrate/20221219065934_add_keyword_to_documents.rb
@@ -1,0 +1,5 @@
+class AddKeywordToDocuments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :documents, :keyword, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_06_041706) do
+ActiveRecord::Schema.define(version: 2022_12_19_065934) do
 
   create_table "action_items", force: :cascade do |t|
     t.integer "uid"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2022_10_06_041706) do
     t.text "location"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "keyword"
     t.index ["project_id"], name: "index_documents_on_project_id"
   end
 
@@ -92,6 +93,7 @@ ActiveRecord::Schema.define(version: 2022_10_06_041706) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "tag_id"
     t.integer "task_state_id"
+    t.text "keyword"
     t.index ["project_id"], name: "index_tasks_on_project_id"
     t.index ["tag_id"], name: "index_tasks_on_tag_id"
     t.index ["task_state_id"], name: "index_tasks_on_task_state_id"


### PR DESCRIPTION
### 概要
タスク一覧と文書一覧に検索機能を追加した．
今回の機能では「内容，担当者，プロジェクト名」であいまい検索が可能である．

### やったこと
+ Gemfile の変更
ransack を使用するために変更を加えた．

+ tasks テーブルにキーワードカラムを追加した．

|  カラム名  |  型  |  内容  |
| ---- | ---- | ---- |
|  keyword  |  text  | 検索に使用したいカラムの内容 |

+ documents テーブルにキーワードカラムを追加した．

|  カラム名  |  型  |  内容  |
| ---- | ---- | ---- |
|  keyword  |  text  | 検索に使用したいカラムの内容 |

+ Task の controller の修正
以下の二点を行うために修正を加えた．
1. ransack を使用する
2. keyword カラムに検索したい内容(今回は内容，担当者，プロジェクト名)を格納する

+ Document の controller の修正
以下の二点を行うために修正を加えた．
1. ransack を使用する
2. keyword カラムに検索したい内容(今回は内容，担当者，プロジェクト名)を格納する

+ Task の view の修正
以下の二点を行うために修正を加えた．
1. 検索フォームの追加
2. 一覧ページへの遷移

+ Document の view の修正
以下の二点を行うために修正を加えた．
1. 検索フォームの追加
2. 一覧ページへの遷移

+ ルーティングの追加
コントローラの 'search' アクションを使用するために Task と Document にルーティングを追加した．

### 結果
**今回は「内容，担当者，プロジェクト名」で検索を行っている．**

**タスク一覧画面**
![image](https://user-images.githubusercontent.com/102787928/208376290-1682088d-f706-4387-a8a4-431b058190b7.png)
**検索フォームで"12345"を入力**
![image](https://user-images.githubusercontent.com/102787928/208376347-e668af0e-da48-4e54-8da8-de9ff2b054e6.png)

内容，担当者，プロジェクト名のいずれかで"12345"を含むものがヒットする．
