### PR TITLE
Fill in title of task like jay

### DIFF
--- a/app/javascript/packs/documents.js
+++ b/app/javascript/packs/documents.js
@@ -1,11 +1,199 @@
-const anchor = document.querySelectorAll("div.jay_document a");
+// Get current region selected by mouse.
+// returns {fst: FIRST_ELEMENT, lst: LAST_ELEMENT}
+getSelectionRange = function() {
+  var range, sel;
+  sel = window.getSelection();
+  console.log("sel:" + sel);
+  if (!sel.isCollapsed && (range = sel.getRangeAt(0))) {
+    return {
+      fst: range.startContainer.parentNode,
+      lst: range.endContainer.parentNode
+    };
+  }
+};
 
-anchor.forEach(function(el){
-    const new_task_url = el.getAttribute("href");
-    el.addEventListener('click', function(el){
-        el.preventDefault();
-        const selectedText = window.getSelection().toString();
-        window.location.href = new_task_url + "&selected_str=" + selectedText;
-    })
-})
+// Get Current line numbers selected by mouse.
+// returns {fst: FIRST_LINE_NUMBER, lst: LAST_LINE_NUMBER}
+getSelectionLineRange = function() {
+  var fst, lst, range;
+  if (!(range = getSelectionRange())) {
+    console.log("gyaa");
+    return void 0;
+  }
+  fst = Number(findNearestLinenum($(range.fst), -1));
+  lst = Number(findNearestLinenum($(range.lst), 1));
+  if (isNaN(fst) || isNaN(lst)) {
+    return void 0;
+  }
+  return {
+    fst: fst,
+    lst: lst
+  };
+};
 
+// Get the nearest data-linenum attribute from ELEMENT
+// including itself. DIRECTION should be +1 or -1
+//
+// returns: value of data-linenum attribute
+//
+findNearestLinenum = function(element, direction) {
+  var buddy, ele, index, name, sel;
+  if (direction == null) {
+    direction = -1;
+  }
+  name = 'data-linenum';
+  sel = "[" + name + "]";
+  ele = $(element);
+  if (ele.is(sel)) {
+    return ele.attr(name);
+  }
+
+  // Since ele does not have data-linenum,
+  // inject a dummy data-linenum to ele, and
+  // find its index among the other data-lineum holders.
+  ele.attr(name, '??');
+  index = $(sel).index(ele);
+  buddy = $(sel)[index + direction];
+  ele.removeAttr(name);
+  return $(buddy).attr(name);
+};
+
+// Scroll to ELEMENT at the center of window
+scrollToCenter = function(element) {
+  var ele, eleH, offset, winH;
+  ele = $(element);
+  eleH = ele.height();
+  winH = $(window).height();
+  offset = ele.offset().top;
+  if (eleH < winH) {
+    offset = offset - ((winH / 2) - (eleH / 2));
+  }
+  return $('html, body').animate({
+    scrollTop: offset
+  }, 600);
+};
+
+// Scroll to AI at the center of window and
+// add class="marked" to highlight
+markAndScrollToActionItem = function(ai) {
+  var ele;
+  ele = $("[data-action-item='" + ai + "']");
+  ele.parent().addClass('marked');
+  return scrollToCenter(ele);
+};
+
+// Get the JSON format of the current page.
+//
+// If the current page is /mintes/1, it will return /minutes/1.json.
+// This function is supposed to be used to get a JSON-style content of
+// currently displayed minute.
+//
+// returns JSON encoded structure.
+//
+getCurrentPageAsJSON = function() {
+  var json, res;
+  res = $.ajax({
+    url: window.location.pathname + ".json",
+    async: false,
+    dataType: 'json'
+  });
+  json = res.responseJSON;
+  console.log("json:" + json);
+  return json;
+};
+
+// Remove Headings of list item ``+ (A) ``
+removeHeader = function(string) {
+  return string.replace(/^ *[*+-] */, '');
+};
+
+// Remove trailing ``-->(...)'' from STRING.
+removeTrailer = function(string) {
+  console.log("string:" + string)
+  return string.replace(/(．)? *--(>|&gt;)\(.*\) */, '');
+};
+
+// Get the minimum indent level of LINES.
+// LINES has multiple lines separated by "\n".
+//
+// For example, if LINES has these three lines:
+//
+// |    first line
+// |      second line
+// |  third line
+//
+// this function returns the minimum indent level as 2.
+// calculated from the third line.
+//
+getIndentLevel = function(lines) {
+  var i, indent, len, line, match, ref;
+  indent = 9999;
+  ref = lines.split("\n");
+  for (i = 0, len = ref.length; i < len; i++) {
+    line = ref[i];
+    match = /^ */.exec(line);
+    if (match && match[0].length < indent) {
+      indent = match[0].length;
+    }
+  }
+  return indent;
+};
+
+// Decrease indents of LINES by LEVEL.
+// LINES has multiple lines separated by "\n".
+//
+// For example, if you call this function with LEVEL is 2 and LINES has
+// these three lines:
+//
+// |    first line
+// |      second line
+// |  third line
+//
+// this function returns:
+//
+// |  first line
+// |    second line
+// |third line
+//
+chopIndentLevel = function(lines, level) {
+  var i, len, line, ref, result, space;
+  if (level === 0) {
+    return lines;
+  }
+  space = new RegExp("^" + (' '.repeat(level)));
+  result = '';
+  ref = lines.split("\n");
+  for (i = 0, len = ref.length; i < len; i++) {
+    line = ref[i];
+    result += line.replace(space, '') + "\n";
+  }
+  return result;
+};
+
+// Decrease indents of LINES to zero.
+chopIndent = function(lines) {
+  return chopIndentLevel(lines, getIndentLevel(lines));
+};
+
+// Extract lines from line number FST to LST.
+extractLines = function(lines, fst, lst) {
+  return lines.split("\n").slice(fst - 1, +(lst - 1) + 1 || 9e9).join("\n");
+};
+
+ready = function() {
+  $('div.jay_document a').on('click', function(event) {
+    var ai_num, description, form, minute, range, title, url;
+    event.preventDefault();
+    if (range = getSelectionLineRange()) {
+      minute = getCurrentPageAsJSON();
+      description = chopIndent(extractLines(minute.description, range.fst, range.lst));
+      title = removeHeader(removeTrailer(description.trim().split("\n").slice(-1)[0]));
+      ai_num = $(this).attr("data-action-item");
+      url = (this.href.split('?')[0]) + "?ai=" + ai_num;
+      const new_task_url = event.target;
+      window.location.href = new_task_url + "&selected_str=" + title;
+    }
+  });
+};
+
+$(document).ready(ready);

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -16,10 +16,10 @@ class Document < ApplicationRecord
   def add_unique_action_item_marker
     desc = ""
     self.description.each_line {|line|
-      matched = line.match(/-->\((.+)\)/)
+    matched = line.match(/-->\(([^!]+)\)/)
       if matched != nil
         @action_item = ActionItem.create(task_url: nil)
-        line.gsub!(/-->\(.+\)/, "-->(#{matched[1]} !#{@action_item.uid})")
+        line.gsub!(/-->\(.+\)/, "-->(#{matched[1]} !:#{@action_item.uid})")
       end
       desc += line
     }

--- a/app/views/documents/_document.json.jbuilder
+++ b/app/views/documents/_document.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! document, :id, :content, :user_id, :created_at, :updated_at, :project_id, :start_at, :end_at, :location,
+json.extract! document, :id, :content, :creator_id, :assigner_id, :description, :created_at, :updated_at, :project_id, :start_at, :end_at, :location
 json.url document_url(document, format: :json)

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -21,11 +21,11 @@
   <div class="jay_document">
     <% desc = JayFlavoredMarkdownConverter.new(@document.description).content %>
     <% desc.each_line do |line| %>
-      <% matched = line.match(/\(([^ ]+) !([0-9]+)\)/) %>
+      <% matched = line.match(/\(([^ ]+) !:([0-9]+)\)/) %>
       <% if matched != nil %>
         <%== $` %>
         <% task_url = ActionItem.find_by(uid:matched[2].to_i).task_url %>
-        <% assigner =  User.find_by(screen_name:matched[1].to_s) %>
+        <% assigner = User.find_by(screen_name:matched[1].to_s) %>
         <% if task_url != nil %>
           <%= link_to matched[0], task_url.to_s %>
         <% else %>


### PR DESCRIPTION
### 概要
宿題記法からタスクを作成する際の，タスクのタイトル自動補完機能を jay と同様に変更した．

### 変更点
変更前はハイライトした文字列でタイトルを補完していたが，今回，ハイライトした文字列の最下行の項番と宿題記法を除いた部分で補完するよう変更した．

![document](https://user-images.githubusercontent.com/81736636/208479744-3313c60c-0468-4edc-a3e6-8d3c418306ab.jpg)
![task](https://user-images.githubusercontent.com/81736636/208479780-3e3afbd3-1abd-4337-b48d-f4ab7f0b624b.jpg)
