### PR TITLE
Remove assigner_id from Document table

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -79,7 +79,7 @@ class DocumentsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def document_params
-    params.require(:document).permit(:assigner_id, :content, :description, :project_id, :start_at, :end_at, :location, :text,)
+    params.require(:document).permit(:creator_id, :content, :description, :project_id, :start_at, :end_at, :location, :text,)
   end
 
   def parse_tag_names(tag_names)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 class Document < ApplicationRecord
   belongs_to :user, foreign_key: 'creator_id'
-  belongs_to :assigner, foreign_key: 'assigner_id', class_name: 'User'
+  belongs_to :creator, foreign_key: 'creator_id', class_name: 'User'
   belongs_to :project, optional: true
   has_many :document_tags, dependent: :destroy
   has_many :tags, through: :document_tags

--- a/app/views/documents/_document.json.jbuilder
+++ b/app/views/documents/_document.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! document, :id, :content, :creator_id, :assigner_id, :description, :created_at, :updated_at, :project_id, :start_at, :end_at, :location
+json.extract! document, :id, :content, :creator_id, :description, :created_at, :updated_at, :project_id, :start_at, :end_at, :location
 json.url document_url(document, format: :json)

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -32,8 +32,8 @@
   </div>
 
   <div class="field my-4">
-    <%= form.label :assigner_id, "作成者", class: "text-xl block font-bold mb-2" %>
-    <%= form.select :assigner_id, @users.map { |u| [u.name, u.id] }, {}, class: "border-2 w-full", required: true%>
+    <%= form.label :creator_id, "作成者", class: "text-xl block font-bold mb-2" %>
+    <%= form.select :creator_id, @users.map { |u| [u.name, u.id] }, {}, class: "border-2 w-full", required: true%>
   </div>
 
   <div class="field my-4">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -10,7 +10,7 @@
       <p class="text-xl"><%= document.content %></p>
       <p>開始日: <%= document.start_at&.strftime('%Y/%m/%d') %></p>
       <p>場所: <%= document.location %></p>
-      <p>作成者: <%= link_to_if document.assigner&.name, document.assigner&.name, document.assigner %></p>
+      <p>作成者: <%= link_to_if document.creator&.name, document.creator&.name, document.creator %></p>
     </div>
     <div class="flex-1"></div>
     <% if logged_in? %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -6,7 +6,7 @@
     〜
     <%= @document.end_at&.strftime('%Y-%m-%d %H:%M') %>
   <p class="text-xl">作成者:
-    <%= link_to_if @document.assigner&.name, @document.assigner.name, @document.assigner %>
+    <%= link_to_if @document.creator&.name, @document.creator.name, @document.creator %>
   <p class="text-xl">所属プロジェクト:
     <%= link_to_if  @document.project&.name, @document.project&.name, @document.project %>
   </p>

--- a/db/migrate/20230215020927_remove_assigner_id_from_documents.rb
+++ b/db/migrate/20230215020927_remove_assigner_id_from_documents.rb
@@ -1,0 +1,5 @@
+class RemoveAssignerIdFromDocuments < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :documents, :assigner_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_06_041706) do
+ActiveRecord::Schema.define(version: 2023_02_15_020927) do
 
   create_table "action_items", force: :cascade do |t|
     t.integer "uid"
@@ -40,7 +40,6 @@ ActiveRecord::Schema.define(version: 2022_10_06_041706) do
     t.integer "creator_id"
     t.datetime "start_at"
     t.datetime "end_at"
-    t.integer "assigner_id"
     t.text "description"
     t.integer "project_id"
     t.text "location"
@@ -114,7 +113,6 @@ ActiveRecord::Schema.define(version: 2022_10_06_041706) do
   add_foreign_key "document_tags", "tags"
   add_foreign_key "documents", "projects"
   add_foreign_key "documents", "projects", on_delete: :cascade
-  add_foreign_key "documents", "users", column: "assigner_id", on_delete: :cascade
   add_foreign_key "documents", "users", column: "creator_id", on_delete: :cascade
   add_foreign_key "projects", "users"
   add_foreign_key "projects", "users", on_delete: :cascade


### PR DESCRIPTION
## やったこと
Document テーブルから assigner_id カラムを削除した．
## 変更点
1. Document テーブルから assigner_id カラムを削除するマイグレーションファイルを作成した．
2. rask/app/views/documents 以下のファイルのうち，assigner_id カラムに関係する箇所を修正した．
3. rask/app/models/document.rb の assigner_id カラムに関係する箇所を修正した．
4. rask/app/controllers/document_controller.rb の assigner_id カラムに関係する箇所を修正した．
