### PR TITLE
Allow tasks to have no deadline

### DIFF
--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,2 +1,10 @@
 module TasksHelper
+  def days_to_deadline_as_string(task)
+    days = task.days_to_deadline
+    if days.finite?
+      "期限まで後" + days.round.to_s + "日です！"
+    else
+      ""
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,14 +9,16 @@ class Task < ApplicationRecord
   belongs_to :state, foreign_key: 'task_state_id', class_name: 'TaskState'
 
   def show_days_ago
-    ((Time.zone.now - self.created_at)/60/60/24).round
+    ((Time.zone.now - self.created_at)/60/60/24)
   end
   def days_to_deadline
-    ((self.due_at - Time.zone.now)/60/60/24).round
+    return Float::INFINITY unless self.due_at
+    ((self.due_at - Time.zone.now)/60/60/24)
   end
 
   def overdue?
-    Time.zone.now.before?(self.due_at)
+    return false unless self.due_at
+    Time.zone.now.after?(self.due_at)
   end
 
   def completed?

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,19 +17,18 @@
         <%= link_to task.content, task %>
       </p>
       <p></p>
-      <p>
-        <% if task.project %>
+      <p>        <% if task.project %>
           <%= link_to task.project.name, task.project %>
         <% end %>
         <%= link_to task.assigner.name, task.assigner %>
-        <%= task.show_days_ago.to_s + "日前" %>
+        <%= task.show_days_ago.round.to_s + "日前" %>
       </p>
     </div>
     <div class="flex-1">
       <% if task.overdue? %>
-      <p class="ongoing_mark"><%= "期限まで後" + task.days_to_deadline.to_s + "日です！" %></p>
+        <p class="overdue_mark">期限切れです！</p>
       <% else %>
-      <p class="overdue_mark">期限切れです！</p>
+        <p class="ongoing_mark"><%= days_to_deadline_as_string task %></p>
       <% end %>
     </div>
     <% if logged_in? %>


### PR DESCRIPTION
#64 に対する PR

## やったこと
期限を持たないタスクを作成しても，一覧画面で落ちないようにした．
overdue? メソッドの処理が名前と反対になっていたため，適切な処理に変更した．