### PR TITLE
Make projects with tasks impossible to be deleted

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  add_flash_types :success, :warning, :danger
 
   # session と params の authenticity_token が一致しない場合，セッションを空にする
   protect_from_forgery with: :null_session

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -52,10 +52,17 @@ class ProjectsController < ApplicationController
 
   # DELETE /projects/1 or /projects/1.json
   def destroy
-    @project.destroy
-    respond_to do |format|
-      format.html { redirect_to projects_url, notice: "プロジェクトを削除しました．" }
-      format.json { head :no_content }
+    begin
+      @project.destroy
+      respond_to do |format|
+        format.html { redirect_to projects_url, notice: "プロジェクトを削除しました．" }
+        format.json { head :no_content }
+      end
+    rescue ActiveRecord::DeleteRestrictionError => e
+      respond_to do |format|
+        format.html { redirect_to projects_url, alert: @project.name + "に紐づいているタスクがあるため削除できません．"}
+        format.json { head :no_content }
+      end
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,5 @@
 class Project < ApplicationRecord
   belongs_to :user
-  has_many :tasks
+  has_many :tasks, dependent: :restrict_with_exception
   has_many :documents
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
   <body>
     <%= render 'layouts/header' %>
     <% flash.each do |message_type, message| %>
-      <% message_color = {:notice => "blue",:success => "blue",:danger => "yellow"} %>
+      <% message_color = {:notice => "blue", :success => "blue", :danger => "yellow", :alert => "red"} %>
       <p class="m-3 p-3 bg-<%= message_color[message_type.to_sym] %>-400 text-white rounded">
         <%= message %>
       </p>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -15,7 +15,11 @@
       <% if logged_in? %>
         <%= link_to '詳細', project %>
         <%= link_to '編集', edit_project_path(project) %>
-        <%= link_to '削除', project, method: :delete, data: { confirm: 'このプロジェクトを削除しますか？' } %>
+        <% if project.tasks.count != 0 %>
+          <p class="text-gray-300">削除</p>
+        <% else %>
+          <%= link_to '削除', project, method: :delete, data: { confirm: 'このプロジェクトを削除しますか？' } %>
+        <% end %>
       <% end %>
     </div>
     <div>

--- a/db/migrate/20230418070335_add_dependent_to_projects.rb
+++ b/db/migrate/20230418070335_add_dependent_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDependentToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :tasks, :integer, :dependent => :restrict_with_exception
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_15_020927) do
+ActiveRecord::Schema.define(version: 2023_04_18_070335) do
 
   create_table "action_items", force: :cascade do |t|
     t.integer "uid"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2023_02_15_020927) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "tasks"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class ProjectsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @project = projects(:one)
+    @project3 = projects(:three)
     @user = users(:one)
     @project.user = @user
     OmniAuth.config.test_mode = true
@@ -22,8 +23,9 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create project" do
     log_in_as(@user)
-    assert_difference('Project.count') do
+    assert_difference('Project.count', 2) do
       post projects_url, params: { project: { name: @project.name, user_id: @project.user_id } }
+      post projects_url, params: { project: { name: @project3.name, user_id: @project3.user_id } }
     end
 
     assert_redirected_to project_url(Project.last)
@@ -47,10 +49,19 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to project_url(@project)
   end
 
-  test "should destroy project" do
+  test "should not destroy project with tasks" do
+    log_in_as(@user)
+    assert_difference('Project.count', 0) do
+      delete project_url(@project)
+    end
+
+    assert_redirected_to projects_url
+  end
+
+  test "should destory project" do
     log_in_as(@user)
     assert_difference('Project.count', -1) do
-      delete project_url(@project)
+      delete project_url(@project3)
     end
 
     assert_redirected_to projects_url

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -9,3 +9,8 @@ two:
   id: 2
   name: MyString
   user_id: 2
+
+three:
+  id: 3
+  name: MyString
+  user_id: 2


### PR DESCRIPTION
# やったこと
紐づいているタスクがあるプロジェクトを削除しようとすると，警告文を出すようにした．
上記の場合，削除ボタンそのものを表示しないことも考えたが，削除できるプロジェクトとそうでないものの違いがユーザにとってわかりにくいかと思ったので，今回の実装内容にした．