### PR TITLE
Add AND search with blank separator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ gem 'dotenv-rails'
 gem 'jay_flavored_markdown', git: 'https://github.com/nomlab/jay_flavored_markdown'
 
 gem 'kaminari'
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,10 @@ GEM
       rake (>= 0.13)
       thor (~> 1.0)
     rake (13.0.3)
+    ransack (3.1.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -320,6 +324,7 @@ DEPENDENCIES
   puma (~> 5.3)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
+  ransack
   rexml
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,10 +2,19 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i[ show edit update destroy ]
   before_action :logged_in_user, only: %i[ new create edit update destroy]
+  before_action :search, only: %i[ index ]
+
+  def search
+    if params[:q]
+      key_words = params[:q][:content_or_assigner_screen_name_or_description_or_project_name_cont].split(/[\p{blank}\s]+/)
+      grouping_hash = key_words.reduce({}){|hash, word| hash.merge(word => { content_or_assigner_screen_name_or_description_or_project_name_cont: word })}
+    end
+    @q = Task.ransack({ combinator: 'and', groupings: grouping_hash })
+  end
 
   # GET /tasks or /tasks.json
   def index
-    @tasks = Task.page(params[:page]).per(50).includes(:user, :state)
+    @tasks = @q.result.page(params[:page]).per(50).includes(:user, :state)
   end
 
   # GET /tasks/1 or /tasks/1.json

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,6 +1,13 @@
 <div class="flex mt-10">
   <%= render 'layouts/h1', title: "文書一覧" %>
   <div class="flex-1"></div>
+  <div class="p-3 my-3 border rounded flex space-x-4">
+  <!--検索フォーム-->
+  <%= search_form_for @q do |f| %>
+    <%= f.text_field :content_or_creator_screen_name_or_description_or_project_name_or_location_cont, placeholder: '検索ワードを入力して下さい' %>
+    <%= f.submit "検索" %>
+  <% end %>
+  </div>
   <%= link_to '新規作成', new_document_path, class: "my-auto text-white bg-red-400 rounded p-2" %>
 </div>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,13 @@
 <div class="flex mt-10">
   <%= render 'layouts/h1', title: "タスク一覧" %>
   <div class="flex-1"></div>
+  <div class="p-3 my-3 border rounded flex space-x-4">
+  <!--検索フォーム-->
+  <%= search_form_for @q do |f| %>
+    <%= f.text_field :content_or_assigner_screen_name_or_description_or_project_name_cont, placeholder: '検索ワードを入力して下さい' %>
+    <%= f.submit "検索" %>
+  <% end %>
+  </div>
   <%= link_to '新規作成', new_task_path, class: "my-auto text-white bg-red-400 rounded p-2" %>
 </div>
 

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,7 @@
+Ransack.configure do |config|
+
+  # Change whitespace stripping behavior.
+  # Default is true
+  config.strip_whitespace = false
+
+end


### PR DESCRIPTION
## やったこと
検索機能のためのGemfileである"ransack"を導入し，文書とタスクに対して，空白区切りでの AND 検索機能を追加した．
検索対象のカラムは以下のとおりである．

**文書**
- タイトル
- 作者(screen name)
- 文書内容
- プロジェクト名
- 場所

**タスク**
- タイトル
- 担当者(screen name)
- 説明
- プロジェクト名

## 変更点
1. Gemfileに"ransack"を追加した．
2.  config/initializers 以下にransack.rb を作成した．
3. 各ページのコントローラーファイルでパラメータの整形処理を記述した．
4. 各ページのビューファイルに検索フォームを記述した．

![image](https://user-images.githubusercontent.com/102787928/232968615-3a9b8553-6008-4d30-9b0f-efba76f240a3.png)