### PR TITLE
Add edit button

### DIFF
--- a/app/javascript/packs/documents.js
+++ b/app/javascript/packs/documents.js
@@ -3,7 +3,6 @@
 getSelectionRange = function() {
   var range, sel;
   sel = window.getSelection();
-  console.log("sel:" + sel);
   if (!sel.isCollapsed && (range = sel.getRangeAt(0))) {
     return {
       fst: range.startContainer.parentNode,
@@ -17,7 +16,6 @@ getSelectionRange = function() {
 getSelectionLineRange = function() {
   var fst, lst, range;
   if (!(range = getSelectionRange())) {
-    console.log("gyaa");
     return void 0;
   }
   fst = Number(findNearestLinenum($(range.fst), -1));
@@ -98,7 +96,6 @@ getCurrentPageAsJSON = function() {
     dataType: 'json'
   });
   json = res.responseJSON;
-  console.log("json:" + json);
   return json;
 };
 
@@ -109,7 +106,6 @@ removeHeader = function(string) {
 
 // Remove trailing ``-->(...)'' from STRING.
 removeTrailer = function(string) {
-  console.log("string:" + string)
   return string.replace(/(．)? *--(>|&gt;)\(.*\) */, '');
 };
 
@@ -181,17 +177,19 @@ extractLines = function(lines, fst, lst) {
 };
 
 ready = function() {
-  $('div.jay_document a').on('click', function(event) {
+  $('div.markdown-body a').on('click', function(event) {
     var ai_num, description, form, minute, range, title, url;
     event.preventDefault();
+    const new_task_url = event.target;
     if (range = getSelectionLineRange()) {
       minute = getCurrentPageAsJSON();
       description = chopIndent(extractLines(minute.description, range.fst, range.lst));
       title = removeHeader(removeTrailer(description.trim().split("\n").slice(-1)[0]));
       ai_num = $(this).attr("data-action-item");
       url = (this.href.split('?')[0]) + "?ai=" + ai_num;
-      const new_task_url = event.target;
       window.location.href = new_task_url + "&selected_str=" + title;
+    } else {
+      window.location.href = new_task_url;
     }
   });
 };

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -21,19 +21,19 @@
   <div class="markdown-body">
     <% desc = JayFlavoredMarkdownConverter.new(@document.description).content %>
     <% desc.each_line do |line| %>
-      <% matched = line.match(/\(([^ ]+) !:([0-9]+)\)/) %>
+      <% matched = line.match(/--(>|&gt;)\(([^ ]+) !:([0-9]+)\)/) %>
       <% if matched != nil %>
         <%== $` %>
-        <% task_url = ActionItem.find_by(uid:matched[2].to_i).task_url %>
-        <% assigner = User.find_by(screen_name:matched[1].to_s) %>
+        <% task_url = ActionItem.find_by(uid:matched[3].to_i).task_url %>
+        <% assigner = User.find_by(screen_name:matched[2].to_s) %>
         <% if task_url != nil %>
           <%= link_to matched[0], task_url.to_s %>
         <% else %>
-          <% message = "Created from [AI#{matched[2]}](#{request.url})" %>
+          <% message = "Created from [AI#{matched[3]}](#{request.url})" %>
           <% if assigner != nil %>
             <% assigner_id =  assigner.id %>
           <% end %>
-          <%= link_to matched[0], new_task_path(assigner_id: assigner_id, project_id: @document.project_id, desc_header: message) %>
+          <%= link_to matched[0].html_safe, new_task_path(assigner_id: assigner_id, project_id: @document.project_id, desc_header: message) %>
         <% end %>
         <%== $' %>
       <% else %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -42,5 +42,6 @@
     <% end %>
     </div>
   </p>
+  <%= link_to '編集', edit_document_path(@document) %>
 </div>
 <%= javascript_pack_tag 'documents' %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,5 +25,5 @@
       <% end %>
     </div>
   <% end %>
-
+  <%= link_to '編集', edit_project_path(@project) %>
 </div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -43,4 +43,5 @@
       <% end %>
     </div>
   <% end %>
+  <%= link_to '編集', edit_tag_path(@tag) %>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -29,3 +29,4 @@
   <p class="text-xl block font-bold mb-2">所属プロジェクト</p>
   <%= link_to @task.project.name, @task.project %>
 </div>
+<%= link_to '編集', edit_task_path(@task) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,3 +28,5 @@
     <% end %>
   <% end %>
 </div>
+
+<%= link_to '編集', edit_user_path(@user) %>


### PR DESCRIPTION
# 概要
プロジェクト，タスク，文書，タグ，ユーザの詳細ページ下部に「編集」リンクを付け足した．
これにより，各詳細ページからそのエントリーの編集ページに遷移できる．

![edit](https://github.com/nomlab/rask/assets/81736636/a39b4149-639e-4ffd-9e24-1c386fa54d76)
