### PR TITLE
Improve layout

### DIFF
--- a/app/views/api_tokens/index.html.erb
+++ b/app/views/api_tokens/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mt-10">
+<div class="flex">
   <% if logged_in? %>
     <%= render 'layouts/h1', title: "APIトークン一覧(#{current_user[:name]})" %>
   <% else %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mt-10">
+<div class="flex">
   <%= render 'layouts/h1', title: "文書一覧" %>
   <div class="flex-1"></div>
   <div class="p-3 my-3 border rounded flex space-x-4">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="bg-red-400 p-3 shadow flex gap-4 text-white fixed right-0 left-0">
+<header class="bg-red-400 p-3 shadow flex gap-4 sticky top-0 right-0 left-0 z-50">
   <%= link_to "Rask", tasks_path, class: 'font-bold' %>
   <div class="flex-1">
     <ul class="flex gap-4">
@@ -6,7 +6,7 @@
       <li><%= link_to "タスク一覧", tasks_path, method: :get %></li>
       <li><%= link_to "文書一覧", documents_path, method: :get %></li>
       <li><%= link_to "タグ一覧", tags_path, method: :get %></li>
-      <li><%= link_to "ユーザー一覧", users_path, method: :get %></li>
+      <li><%= link_to "ユーザ一覧", users_path, method: :get %></li>
       <li><%= link_to "APIトークン一覧", api_tokens_path, method: :get %></li>
       <li><%= link_to "Raskについて(GitHub)", 'https://github.com/nomlab/rask/blob/main/README.md', method: :get %></li>
     </ul>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,4 +1,4 @@
-<div class="border mx-auto mt-10 p-3">
+<div class="border mx-auto p-3">
   <p class="font-bold text-xl mb-3">メニュー</p>
   <ul>
     <li class="my-1"><%= link_to "プロジェクト一覧", projects_path %></li>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mt-10">
+<div class="flex">
   <%= render 'layouts/h1', title: "プロジェクト一覧" %>
   <div class="flex-1"></div>
   <%= link_to '新規作成', new_project_path, class: "my-auto text-white bg-red-400 rounded p-2" %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mt-10">
+<div class="flex">
   <%= render 'layouts/h1', title: "タグ一覧" %>
   <div class="flex-1"></div>
   <%= link_to '新規作成', new_tag_path, class: "my-auto text-white bg-red-400 rounded p-2" %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex mt-10">
+<div class="flex">
   <%= render 'layouts/h1', title: "タスク一覧" %>
   <div class="flex-1"></div>
   <div class="p-3 my-3 border rounded flex space-x-4">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-10">
+<div class="flex">
   <%= render 'layouts/h1', title: "ユーザ一覧" %>
 </div>
 


### PR DESCRIPTION
# 修正点

1. ヘッダが最前面に来るように (z-index を調整) した．
議事録などの hタグのテキストがヘッダよりも前面に来ている問題に対処した．
3. 各ページの上部とヘッダが重ならないように修正した．
詳細ページなどで，ページの上部とヘッダが重なっていた問題に対処した．