### PR TITLE
Change color of status icon on /tasks

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -15,11 +15,10 @@
   <div class="p-3 my-3 border rounded flex space-x-4">
     <div>
       <p class="text-xl">
-        <% if task.state.name=="todo" %>
-          <i class="far fa-dot-circle"></i>
-        <% end %>
-        <% if task.state.name=="done" %>
-          <i class="far fa-check-circle"></i>
+        <% if task.completed? %>
+          <i class="far fa-check-circle" style="color: <%= task.state.color %>;"></i>
+        <% else %>
+          <i class="far fa-dot-circle" style="color: <%= task.state.color %>;"></i>
         <% end %>
         <%= link_to task.content, task %>
       </p>


### PR DESCRIPTION
## 概要

タスク一覧ページにおいて，タスクの状態を左側に表示されるアイコンの色で判別できるようにした．

色はtask_statesテーブルのcolorカラムによって決まる．

## スクリーンショット

上から順に，todo，done，draft のタスクが表示されている．

![image](https://github.com/nomlab/rask/assets/65284522/da485f97-4960-486a-bd95-f9fdbc40fa13)
