### PR TITLE
Updated Rask username not to be null

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
             user.uid      = auth["uid"]
 
             info = auth["info"]
-            user.name        = info["name"]
+            user.name        = info["name"] || info["nickname"]
             user.screen_name = info["nickname"]
             user.avatar_url  = info["image"]
         end


### PR DESCRIPTION
## 概要
Rask に初回ログイン時，GitHub のユーザ名が未設定ならばニックネームを Rask のユーザ名にするようにした．

## 変更点
user.nameにinfo{"nickname"}を追加した．