### PR TITLE
Add account name & active status display to /users

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,21 @@
 // Place all the styles related to the Users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.user-tile {
+  display: grid;
+  grid-template-columns: 2em 1fr;
+}
+
+.user-tile-icon {
+  position: relative;
+
+  :first-child {
+    position: absolute;
+    bottom: 0.5rem;
+  }
+}
+
+.user-tile-profile {
+  grid-column-start: 2;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <%= stylesheet_pack_tag "application", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'tab' %>
     <%= stylesheet_link_tag 'tasks' %>
+    <%= stylesheet_link_tag 'users' %>
     <%= stylesheet_link_tag 'jfm' %>
     <%= stylesheet_link_tag 'github-markdown' %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,8 +4,16 @@
 
 <% @users.each do |user| %>
   <div class="p-3 my-3 border rounded flex space-x-4">
-    <div>
-      <p class="text-xl"><%= user.name %></p>
+    <div class="user-tile <%= 'text-gray-400' unless user.active %>">
+      <div class="user-tile-icon">
+        <% if user.active %>
+          <i class="fas fa-user-alt fa-lg"></i>
+        <% else %>
+          <i class="fas fa-user-alt-slash fa-lg"></i>
+        <% end %>
+      </div>
+      <p class="user-tile-profile text-xl">ユーザ名: <%= user.name %></p>
+      <p class="user-tile-profile text-xl">アカウント名:<%= user.screen_name %></p>
     </div>
     <div class="flex-1"></div>
     <% if logged_in?  && current_user?(user) %>


### PR DESCRIPTION
## 概要
ユーザ一覧ページにおいて，アカウント名を追加し，アクティブなメンバーかをアイコンと色で判別できるようにした．

## スクリーンショット
アクティブなメンバーの場合．
![rask_active_user](https://github.com/nomlab/rask/assets/115961722/0ef54648-8234-4b96-b898-99dbe80f11f1)
非アクティブなメンバーの場合．
![rask_nonactive_user](https://github.com/nomlab/rask/assets/115961722/618b3d70-1642-47ed-bade-082e142b6dd8)
