### PR TITLE
Add sorting in Documents and Tasks

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -2,6 +2,17 @@
   <%= render 'layouts/h1', title: "文書一覧" %>
   <div class="flex-1"></div>
   <div class="p-3 my-3 border rounded flex space-x-4">
+    <thead>
+      <tr>
+        <th>ソート：</th>
+        <th><%= sort_link(@q, :content, "タイトル順" )%></th>
+        <th><%= sort_link(@q, :updated_at, "更新順")%></th>
+        <th><%= sort_link(@q, :created_at, "作成順")%></th>
+        <th><%= sort_link(@q, :start_at, "開始時刻順")%></th>
+      </tr>
+    </thead>
+  </div>
+  <div class="p-3 my-3 border rounded flex space-x-4">
   <!--検索フォーム-->
   <%= search_form_for @q do |f| %>
     <%= f.text_field :content_or_creator_screen_name_or_description_or_project_name_or_location_cont, placeholder: '検索ワードを入力して下さい' %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,18 @@
 <div class="flex">
   <%= render 'layouts/h1', title: "タスク一覧" %>
-  <div class="flex-1"></div>
+  <div class="flex-1">
+  </div>
+  <div class="p-3 my-3 border rounded flex space-x-4">
+    <thead>
+      <tr>
+        <th>ソート：</th>
+        <th><%= sort_link(@q, :updated_at, "更新順") %></th>
+        <th><%= sort_link(@q, :created_at, "作成順") %></th>
+        <th><%= sort_link(@q, :due_at, "期限順") %></th>
+        <th><%= sort_link(@q, :project_id, "プロジェクト名順") %></th>
+      </tr>
+    </thead>
+  </div>
   <div class="p-3 my-3 border rounded flex space-x-4">
   <!--検索フォーム-->
   <%= search_form_for @q do |f| %>


### PR DESCRIPTION
## やったこと
"ransack"を用いて，文書とタスクに対して，ソート機能を追加した．
デフォルトでは「文書 : 開始日の降順（新しい順）」「タスク : タスクの状態の昇順」としている．
ソート対象のカラムは以下のとおりである．
**文書**
- タイトル順
- 更新順
- 作成順
- 開始時刻順

**タスク**
- 更新順
- 作成順
- 期限順
- プロジェクト名順

またタスクについては，**上記のソートかつタスクの状態順**の複数ソートとしている．

## 変更点
1. 各ページのコントローラーファイルでパラメータの整形処理を記述した．
2. 各ページのビューファイルにソートフォームを記述した．