### PR TITLE
Support for docker compose subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 up:
-	docker-compose up -d
+	docker compose up -d
 
 setup:
-	docker-compose exec myapp bash -c 'bundle install'
-	docker-compose exec myapp bash -c 'bundle exec rails webpacker:install'
-	docker-compose exec myapp bash -c 'bundle exec rails tailwindcss:install'
-	docker-compose exec myapp bash -c 'bundle exec rails db:migrate'
+	docker compose exec myapp bash -c 'bundle install'
+	docker compose exec myapp bash -c 'bundle exec rails webpacker:install'
+	docker compose exec myapp bash -c 'bundle exec rails tailwindcss:install'
+	docker compose exec myapp bash -c 'bundle exec rails db:migrate'
 
 start:
-	docker-compose exec myapp bash -c 'bundle exec rails server -b 0.0.0.0'
+	docker compose exec myapp bash -c 'bundle exec rails server -b 0.0.0.0'
 
 myapp:
-	docker-compose exec myapp bash
+	docker compose exec myapp bash
 
 down:
-	docker-compose down --rmi all --volumes
+	docker compose down --rmi all --volumes
 
 rails-test:
-	docker-compose exec myapp bundle exec rails test
+	docker compose exec myapp bundle exec rails test


### PR DESCRIPTION
# 概要
Raskの開発環境において，プラグイン版 docker compose だと make up に失敗していたため，docker compose でmake up できるようにした

# 変更点
Makefileの内容をdocker-compose コマンドを使用している状態からdocker compose サブコマンドに変更した