### PR TITLE
Fix a bug in the detail page

### DIFF
--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -7,7 +7,7 @@
 
 <div class="my-3">
   <p class="text-xl block font-bold mb-2">期限</p>
-  <%= @task.due_at.to_s(:datetime_jp) %>
+  <%= @task.due_at&.to_s(:datetime_jp) %>
 </div>
 
 <div class="my-3">
@@ -27,6 +27,6 @@
 
 <div class="my-3">
   <p class="text-xl block font-bold mb-2">所属プロジェクト</p>
-  <%= link_to @task.project.name, @task.project %>
+  <%= link_to @task.project.name, @task.project if @task.project %>
 </div>
 <%= link_to '編集', edit_task_path(@task) %>


### PR DESCRIPTION
## 概要
必要項目がないことによって詳細ページが落ちるバグの修正をした．

## 変更点
タスク詳細ページでタスクの期限および所属プロジェクトが設定されていない際にエラーが出ていた．
期限および所属プロジェクトが設定されていない場合でも正常に表示されるように修正した．