### PR TITLE
Remove a creator field from a document form

### DIFF
--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -32,11 +32,6 @@
   </div>
 
   <div class="field my-4">
-    <%= form.label :creator_id, "作成者", class: "text-xl block font-bold mb-2" %>
-    <%= form.select :creator_id, @users.map { |u| [u.name, u.id] }, {}, class: "border-2 w-full", required: true%>
-  </div>
-
-  <div class="field my-4">
     <%= form.label :project_id, "プロジェクト名", class: "text-xl block font-bold mb-2" %>
     <%= form.select :project_id, @projects.map { |p| [p.name, p.id] }, { include_blank: true }, class: "border-2 w-full", required: false %>
   </div>


### PR DESCRIPTION
## 概要
文書の作成の際にログインしているユーザを作成者にする．

## 変更点
文書作成フォームから作成者の項目を削除した．
元からログインしているユーザが作成者に設定されるようになっていた．