### PR TITLE
Prevent page transition in editing tasks or documents

### DIFF
--- a/app/javascript/packs/prevent_transition_in_editing.js
+++ b/app/javascript/packs/prevent_transition_in_editing.js
@@ -1,0 +1,20 @@
+// prevent closing tab or jumping another page in editing
+const beforeUnloadHandler = (e) => {
+  e.preventDefault();
+  e.returnValue = '';
+};
+
+let registered = false;
+const editableElements = document.querySelectorAll('input,select,textarea');
+editableElements.forEach((element) => {
+  element.addEventListener('change', (e) => {
+    if (registered) return;
+    registered = true;
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+  });
+});
+
+const form = document.getElementById('editor');
+form.addEventListener('submit', (e) => {
+  window.removeEventListener('beforeunload', beforeUnloadHandler);
+});

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: document) do |form| %>
+<%= form_with(model: document, id: 'editor') do |form| %>
   <% if document.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(document.errors.count, "error") %> prohibited this document from being saved:</h2>
@@ -119,4 +119,5 @@ fetch("/documents/api_markdown", {method, headers, body}).then((res)=> res.json(
   }
   </script>
 
+  <%= javascript_pack_tag 'prevent_transition_in_editing' %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: task) do |form| %>
+<%= form_with(model: task, id: 'editor') do |form| %>
   <% if task.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(task.errors.count, "error") %> prohibited this task from being saved:</h2>
@@ -59,4 +59,6 @@
   <div class="actions">
     <%= form.submit "保存", class: "bg-red-400 p-2 text-white rounded w-full" %>
   </div>
+
+  <%= javascript_pack_tag 'prevent_transition_in_editing' %>
 <% end %>


### PR DESCRIPTION
## 概要

タスク・文書の編集ビューにおいて，何らかの項目を1度でも変更するとページ遷移時に確認ポップアップが出るようにした．

## 変更点

* `prevent_transition_in_editing.js` というスクリプトを作成し，`app/javascript/packs` に配置した．
* 上記スクリプトを `app/views/document/_form.html.erb` と `app/views/task/_form.html.erb` から読み込むようにした．
  * これらの view に含まれる form 要素に `id="editor"` の HTMLAttribute を追加した．
    これは，submit 時のみ確認をスキップして遷移させるためである．