### PR TITLE
Show logged-in user on header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
   </div>
   <ul class="flex gap-4">
     <% if logged_in? %>
-      <li><%= link_to "ログアウト", logout_path, method: :delete, data: { confirm: 'ログアウトしますか？' } %></li>
+      <li><%= link_to "ログアウト (#{current_user.screen_name})", logout_path, method: :delete, data: { confirm: 'ログアウトしますか？' } %></li>
     <% else %>
       <li><%= link_to "ログイン", '/auth/github', method: :post %></li>
     <% end %>


### PR DESCRIPTION
## 概要

ヘッダーに現在ログインしているユーザのアカウント名 (screen_name) を表示されるようにした．

![image](https://github.com/nomlab/rask/assets/65284522/e094b7e8-c5a6-4978-a2af-4ec01a173c65)
