### PR TITLE
Fix bug not to be able to delete tagged document

### DIFF
--- a/db/migrate/20230824085144_add_primary_key_to_document_tags.rb
+++ b/db/migrate/20230824085144_add_primary_key_to_document_tags.rb
@@ -1,0 +1,5 @@
+class AddPrimaryKeyToDocumentTags < ActiveRecord::Migration[6.1]
+  def change
+    add_column :document_tags, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_18_101055) do
+ActiveRecord::Schema.define(version: 2023_08_24_085144) do
 
   create_table "action_items", force: :cascade do |t|
     t.integer "uid"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2023_04_18_101055) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "document_tags", id: false, force: :cascade do |t|
+  create_table "document_tags", force: :cascade do |t|
     t.integer "document_id", null: false
     t.integer "tag_id", null: false
     t.index ["document_id"], name: "index_document_tags_on_document_id"


### PR DESCRIPTION
## 概要

タグ付けされた文書が削除できない問題を修正した．

## 変更点

`document_tags` テーブルに primary key がなかったため，primary key として `id` カラムを追加した．