### PR TITLE
Make tasks with tasks and documents impossible to be deleted

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -50,10 +50,17 @@ class TagsController < ApplicationController
 
   # DELETE /tags/1 or /tags/1.json
   def destroy
-    @tag.destroy
-    respond_to do |format|
-      format.html { redirect_to tags_url, notice: "タグを削除しました．" }
-      format.json { head :no_content }
+      begin
+        @tag.destroy
+        respond_to do |format|
+          format.html { redirect_to tags_url, notice: "タグを削除しました．" }
+          format.json { head :no_content }
+        end
+      rescue ActiveRecord::DeleteRestrictionError => e
+        respond_to do |format|
+          format.html { redirect_to tags_url, alert: @tag.name + "に紐づいているタスク，ドキュメントがあるため削除できません．"}
+          format.json { render json: @tag.errors, status: :precondition_failed}
+      end
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,7 @@
 class Tag < ApplicationRecord
   has_many :task_tags, dependent: :destroy
-  has_many :tasks, through: :task_tags
+  has_many :tasks, through: :task_tags, dependent: :restrict_with_exception
   has_many :document_tags, dependent: :destroy
-  has_many :documents, through: :document_tags
+  has_many :documents, through: :document_tags, dependent: :restrict_with_exception
   validates :name, presence: true, uniqueness: true
 end

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -8,6 +8,10 @@
   <% if logged_in? %>
     <%= link_to '詳細', tag %>
     <%= link_to '編集', edit_tag_path(tag) %>
-    <%= link_to '削除', tag, method: :delete, data: { confirm: 'このタグを削除しますか？' } %>
+    <% if tag.tasks.count == 0 && tag.documents.count == 0 %>
+      <%= link_to '削除', tag, method: :delete, data: { confirm: 'このタグを削除しますか？' } %>
+    <% else %>
+      <p class="text-gray-300">削除</p>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
## やったこと
紐づいているタスクやドキュメントがあるタグには削除の表示を灰色にし，クリックできないものとした．
また，APIで直接削除を行う場合も考慮して，データベースの制約としても紐づいているタスクやドキュメントがあるタグは削除できないようにした．