### PR TITLE
Scroll to highlighted SYUKUDAI_NOTATION line automatically

### DIFF
--- a/app/javascript/packs/documents.js
+++ b/app/javascript/packs/documents.js
@@ -1,3 +1,18 @@
+//
+// Get URL params as Object
+//
+getUrlParams = function() {
+  var i, key, len, param, params, ref, ref1, val;
+  params = {};
+  ref = window.location.search.substr(1).split('&');
+  for (i = 0, len = ref.length; i < len; i++) {
+    param = ref[i];
+    ref1 = param.split('='), key = ref1[0], val = ref1[1];
+    params[key] = decodeURIComponent(val);
+  }
+  return params;
+};
+
 // Get current region selected by mouse.
 // returns {fst: FIRST_ELEMENT, lst: LAST_ELEMENT}
 getSelectionRange = function() {
@@ -177,6 +192,10 @@ extractLines = function(lines, fst, lst) {
 };
 
 ready = function() {
+  var ai;
+  if (ai = getUrlParams().ai) {
+    markAndScrollToActionItem(ai);
+  }
   $('div.markdown-body a').on('click', function(event) {
     var ai_num, description, form, minute, range, title, url, params, desc_header;
     event.preventDefault();

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -33,7 +33,7 @@
         <% if task_url != nil %>
           <%= link_to "(#{matched[2]} #{task_url})", task_url.to_s %>
         <% else %>
-          <% message = "Created from [AI#{matched[3]}](#{request.url})" %>
+          <% message = "Created from [AI#{matched[3]}](#{request.url.split('?').first}?ai=#{matched[3]})" %>
           <% if assigner != nil %>
             <% assigner_id =  assigner.id %>
           <% end %>


### PR DESCRIPTION
## 概要
宿題記法により作成されたタスクの説明に挿入される作成元の文書へのリンクを踏むと，当該行をハイライトしその箇所まで自動でスクロールする機能を jay から移植した．

### 補足
jay では，宿題記法から作成したタスクの説明に挿入される文書へのリンクを `request.url` を用いて現在の URL を取得している．しかし，この方法ではクエリパラメータも取得してしまう．自動スクロールが行われる場合はパラメータが付与されているため，前述の手法で現在のリンクを取得すると不適切なパラメータが含まれてしまう．そのため，`request.url.split('?').first` とすることで，パラメータを除く現在の URL を取得するようにした．

![highlight](https://github.com/nomlab/rask/assets/81736636/a1e05d33-a779-41c1-b031-9e08d0529262)
