### PR TITLE
Add content presence validation

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,6 +8,8 @@ class Task < ApplicationRecord
   accepts_nested_attributes_for :task_tags, allow_destroy: true
   belongs_to :state, foreign_key: 'task_state_id', class_name: 'TaskState'
 
+  validates :content, presence: true
+
   def show_days_ago
     ((Time.zone.now - self.created_at)/60/60/24)
   end


### PR DESCRIPTION
## 概要
task の model について，content 属性の validation を追加した．
タスクの内容が空の場合，データベースへの保存が無効になる．

## 変更点
app/models/task.rb に `validates :content, presence: true` を追加．