### PR TITLE
Fix user model validate

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
     # github action uses the provider name "github"
     validate do |record|
       if (record.password_digest.blank? && record.provider != "github") then
-        record.errors.add(attribute, :blank)
+        record.errors.add(:base, "Password is blank and provider is not GitHub")
       end
     end
     validates_length_of :password, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -54,7 +54,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not create local user with empty password_digest" do
-    skip 'Exception'
     user = @user_template.clone
     user[:provider] = "local"
     user[:password_digest] = nil


### PR DESCRIPTION
## 概要
user のモデルテストでエラーで落ちていた箇所を修正した．
`"should not create local user with empty password_digest"`のテストで以下のエラーが出ていた．
> E
Error:
UserTest#test_should_create_github_user_with_empty_password_digest:
ArgumentError: wrong number of arguments (given 0, expected 1)
    　app/models/user.rb:7:in \`block in <class:User>'
    　test/models/user_test.rb:49:in `block in <class:UserTest>'

エラーの原因は model/user.rb の7行目の`record.errors.add(attribute, :blank)`の `attribute` だったと思われる．

変更後はテストが問題なく通った．