### PR TITLE
Fix tasks fixture to pass test/validation

### DIFF
--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -14,7 +14,6 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get index with login" do
-    skip 'Exception'
     log_in_as(@user)
     get tasks_url
     assert_response :success
@@ -32,10 +31,9 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create task" do
-    skip 'Exception'
     log_in_as(@user)
     assert_difference('Task.count') do
-    post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, project_id: @task.project_id, task_state_id: @task.task_state_id} }
+      post tasks_url, params: { task: { content: @task.content, creator_id: @task.creator_id, assigner_id: @task.assigner_id , due_at: @task.due_at, description: @task.description, project_id: @task.project_id, task_state_id: @task.task_state_id} }
     end
 
     assert_redirected_to tasks_url

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -3,10 +3,10 @@
 one:
   content: MyText
   user: one
-  assigner_id: one
+  assigner: one
   due_at: 2021-07-16 12:22:22
   description: test
-  project_id : one
+  project : one
   state: todo
 
 two:


### PR DESCRIPTION
## 概要

tasks_controller_test のうち，以下2つの test を skip しないようにした (通るようにした)．
+ should get index with login
+ should create task

## 原因と修正内容

テストに用いる task インスタンスについて，assigner_id が正しく設定されていなかった．
そのため fixture を以下のように修正した．

```test/fixtures/tasks.yml.diff
-  assigner_id: one
+  assigner: one
```