### PR TITLE
Add 'should delete task_state have no task' and 'should not delete task_state have task'

### DIFF
--- a/app/models/task_state.rb
+++ b/app/models/task_state.rb
@@ -1,2 +1,3 @@
 class TaskState < ApplicationRecord
+  has_many :tasks, dependent: :restrict_with_exception
 end

--- a/test/models/task_state_test.rb
+++ b/test/models/task_state_test.rb
@@ -16,10 +16,23 @@ class TaskStateTest < ActiveSupport::TestCase
     assert_not TaskState.new(name: "test").valid?
   end
 
-  test "should delete task_state" do
-    skip 'Exception'
-    TaskState.new(name: "test", priority: 0)
-    assert_not TaskState.last.destroy
+  test "should delete task_state have no task" do
+    TaskState.create(name: "test", priority: 0)
+    assert TaskState.last.destroy
+  end
+
+  test "should not delete task_state have task" do
+    TaskState.create(name: "test", priority: 0)
+    Task.create(creator_id: users(:one).id,
+                assigner_id: users(:two).id,
+                due_at: Time.zone.now,
+                project_id: projects(:one).id,
+                content: 'testtask',
+                task_state_id: TaskState.last.id,
+                description: "This is test task")
+    assert_raises(ActiveRecord::DeleteRestrictionError) do
+      TaskState.last.destroy
+    end
   end
 
 end


### PR DESCRIPTION
## 概要
以下のtask_stateに関するモデルテストを追加した．

1. taskに紐付いていないtask_stateを削除するテスト
2. taskに紐付いているtask_stateを削除できないか確認するテスト
## 変更点
app/models/task_state.rbにtask_stateを削除する際，関連付けられたレコードがある場合にActiveRecord::DeleteRestrictionError例外を発生させ，削除できなくする処理を記述した．
test/models/task_state_test.rb に概要で述べた２つのテストを追加した．
