### PR TITLE
Fix tag model to pass test

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -50,16 +50,16 @@ class TagsController < ApplicationController
 
   # DELETE /tags/1 or /tags/1.json
   def destroy
-      begin
-        @tag.destroy
-        respond_to do |format|
-          format.html { redirect_to tags_url, notice: "タグを削除しました．" }
-          format.json { head :no_content }
-        end
-      rescue ActiveRecord::DeleteRestrictionError => e
-        respond_to do |format|
-          format.html { redirect_to tags_url, alert: @tag.name + "に紐づいているタスク，ドキュメントがあるため削除できません．"}
-          format.json { render json: @tag.errors, status: :precondition_failed}
+    begin
+      @tag.destroy
+      respond_to do |format|
+        format.html { redirect_to tags_url, notice: "タグを削除しました．" }
+        format.json { head :no_content }
+      end
+    rescue ActiveRecord::DeleteRestrictionError => e
+      respond_to do |format|
+        format.html { redirect_to tags_url, alert: @tag.name + "に紐づいているタスク，ドキュメントがあるため削除できません．"}
+        format.json { render json: @tag.errors, status: :precondition_failed}
       end
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,7 @@
 class Tag < ApplicationRecord
-  has_many :task_tags, dependent: :destroy
+  has_many :task_tags
   has_many :tasks, through: :task_tags, dependent: :restrict_with_exception
-  has_many :document_tags, dependent: :destroy
+  has_many :document_tags
   has_many :documents, through: :document_tags, dependent: :restrict_with_exception
   validates :name, presence: true, uniqueness: true
 

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -12,5 +12,6 @@ tag_has_task:
     # tasks: one # FIXME: This syntax is currently not working for NotNullViolation exception for created_at column
 
 tag_has_document:
+  id: 2
   name: tag_has_document
-  documents: one
+  # documents: one

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -16,7 +16,6 @@ class DocumentTest < ActiveSupport::TestCase
   end
 
   test "Should delete document" do
-    p("\n\n\n\ncheck\n\n\n\n")
     document = Document.create(content: 'test', description: 'test')
     assert document.destroy
   end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -20,9 +20,10 @@ class TagTest < ActiveSupport::TestCase
   end
 
   test "should not delete tag which has task" do
-    skip 'This test cause Exception.'
     tag = tags(:tag_has_task)
-    assert_not tag.destroy
+    assert_raises(ActiveRecord::DeleteRestrictionError) do
+      tag.destroy
+    end
   end
 
   test "should not delete tag which has document" do


### PR DESCRIPTION
## 概要
テスト `should_not_delete_tag_which_has_task` が通るようにタグのモデルを修正．
また，テスト自体も"特定のエラーを検知する"に変更．

## 変更点
+ タグの削除時にタグとタスクの中間テーブルを削除しないように変更．
+ テストを `assert_not()` から `assert_raises()` に変更．
  +  `assert_raises()` は特定の例外が発生するかを検証する．