### PR TITLE
Fix 'should not create task without creator_id' and 'should not create task without content'

### DIFF
--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -19,17 +19,15 @@ class TaskTest < ActiveSupport::TestCase
   end
 
   test "should not create task without creator_id" do
-    skip ''
     task = @task_template.clone
     task[:creator_id] = nil
-    assert Task.new(task).save
+    assert_not Task.new(task).save
   end
 
   test "should not create task without content" do
-    skip ''
     task = @task_template.clone
     task[:content] = nil
-    assert Task.new(task).save
+    assert_not Task.new(task).save
   end
 
   test "should delete task" do


### PR DESCRIPTION
## 概要
以下のtaskに関するテストを修正した．

1. creator_id が設定されてない task が作成されないか確認するテスト
2. content が設定されてない task が作成されないか確認するテスト
## 変更点
test/models/task_test.rbの should not create task without creator_id() および should not create task without content() において，
これらで save した場合の結果が false であるべきなので，assert を assert_not に変更した．