### PR TITLE
Fix model test so that tag test passes

### DIFF
--- a/test/models/task_tag_test.rb
+++ b/test/models/task_tag_test.rb
@@ -21,12 +21,11 @@ class TaskTagTest < ActiveSupport::TestCase
   end
 
   test "Should delete tag which has no tasks" do
-    skip ''
     Task.create
     Tag.create
     TaskTag.create(task_id: Task.last.id, tag_id: Tag.last.id)
     Task.last.delete
-    assert TaskTag.last.destroy.valid?
+    assert Tag.last.destroy
   end
 
   test "Should not delete tag which has tasks" do


### PR DESCRIPTION
## 概要
テスト `should delete tag which has no tasks` が通るようにモデルのテストを修正．

## 変更点
+ タスクとタグの中間テーブルを削除していた部分をタグのテーブルの削除に変更．
+ validation が成功するかを評価していたが，削除できるかどうかを評価するべきであるため， `.validate?` は削除