### PR TITLE
Fix 'should not create document without content' and Add 'should not create document without others' 

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,6 +7,7 @@ class Document < ApplicationRecord
   has_many :tags, through: :document_tags
   accepts_nested_attributes_for :document_tags, allow_destroy: true
 
+  validates :content, presence: true
   validates :start_at, presence: true
   validates :end_at, presence: true
   validates :location, presence: true

--- a/test/models/api_token_test.rb
+++ b/test/models/api_token_test.rb
@@ -2,10 +2,21 @@ require "test_helper"
 require 'securerandom'
 
 class ApiTokenTest < ActiveSupport::TestCase
+  def setup
+    @user_template = {
+      name: "Test User",
+      screen_name: "test-user",
+      provider: "test-provider",
+      password_digest: "password",
+      uid: "test-uid",
+      avatar_url: "test-url",
+      active: true
+    }
+  end
 
   test "should create with correct data" do
-    skip ''
-    assert ApiToken.new(secret: "rask-"+ SecureRandom.uuid, user_id: 1).valid?
+    user = @user_template.clone
+    assert ApiToken.create(secret: "rask-"+ SecureRandom.uuid, user_id: User.last.id).valid?
   end
 
   test "should not create api_token without secret" do
@@ -17,8 +28,8 @@ class ApiTokenTest < ActiveSupport::TestCase
   end
 
   test "should update description" do
-    skip ''
-    ApiToken.create(secret:"rask-"+ SecureRandom.uuid, user_id: 1)
+    user = @user_template.clone
+    ApiToken.create(secret:"rask-"+ SecureRandom.uuid, user_id: User.last.id)
     assert ApiToken.last.update(description: "Test")
   end
 

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -4,14 +4,28 @@ class DocumentTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end
+  def setup
+    @user_template = {
+      name: "Test User",
+      screen_name: "test-user",
+      provider: "test-provider",
+      password_digest: "password",
+      uid: "test-uid",
+      avatar_url: "test-url",
+      active: true
+    }
+  end
 
   test "Should create document with correct data" do
-    skip ''
-    assert Document.new(content: 'test', description: 'test').save
+    user = @user_template.clone
+    Project.create(name: 'testdata', user_id: users(:one).id)
+    document = Document.create(content: 'test', description: 'test', start_at: Time.now,
+                                end_at: Time.now + 1.hour, location: 'Test Location',
+                                user: User.last, creator: User.last, project: Project.last)
+    assert document.valid?
   end
 
   test "Should not create document without content" do
-    skip ''
     assert_not Document.new.save
   end
 

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -5,28 +5,56 @@ class DocumentTest < ActiveSupport::TestCase
   #   assert true
   # end
   def setup
-    @user_template = {
-      name: "Test User",
-      screen_name: "test-user",
-      provider: "test-provider",
-      password_digest: "password",
-      uid: "test-uid",
-      avatar_url: "test-url",
-      active: true
+    @document_templete = {
+      content: 'test',
+      description: 'test',
+      start_at: Time.now,
+      end_at: Time.now + 1.hour,
+      location: 'Test Location',
+      user: users(:one),
+      creator: users(:one),
+      project: projects(:one)
     }
   end
-
   test "Should create document with correct data" do
-    user = @user_template.clone
-    Project.create(name: 'testdata', user_id: users(:one).id)
-    document = Document.create(content: 'test', description: 'test', start_at: Time.now,
-                                end_at: Time.now + 1.hour, location: 'Test Location',
-                                user: User.last, creator: User.last, project: Project.last)
+    document = Document.create(@document_templete)
     assert document.valid?
   end
 
+  test "Should not create document without start_at" do
+    document = Document.new(@document_templete)
+    document.start_at = nil
+    assert_not document.valid?
+  end
+
+  test "Should not create document without end_at" do
+    document = Document.new(@document_templete)
+    document.end_at = nil
+    assert_not document.valid?
+  end
+
+  test "Should not create document without location" do
+    document = Document.new(@document_templete)
+    document.location = nil
+    assert_not document.valid?
+  end
+
+  test "Should not create document without user" do
+    document = Document.new(@document_templete)
+    document.user = nil
+    assert_not document.valid?
+  end
+
+  test "Should not create document without creator" do
+    document = Document.new(@document_templete)
+    document.creator = nil
+    assert_not document.valid?
+  end
+
   test "Should not create document without content" do
-    assert_not Document.new.save
+    document = Document.new(@document_templete)
+    document.content = nil
+    assert_not document.valid?
   end
 
   test "Should delete document" do


### PR DESCRIPTION
## 概要
以下のテストが通るようにテストの内容を修正，Modelにてバリデーションを追加した．
+ api_token_test.rb
  + should create with correct data
  + should update description
+ document_test.rb
  + should create document with correct data
  + should not create document without content 

また，document.rb のバリデーションを参考に，以下のテストを追加した．
+ document_test.rb
  + should not create document without start_at
  + should not create document without end_at
  + should not create document without location
  + should not create document without user
  + should not create document without creator

## 変更点
+ `should create with correct data`と`should update description`
  + テスト内でユーザを作成し，api_token 作成時にそのユーザの ID を渡すように変更．
+ `should create document with correct data`
  + テンプレートを用いてテストを行うように変更．
+ `should not create document without content `
  + content に対してバリデーションを定義し，空でないかを検証するように変更．
+ `should not create document without content`
  + skip を消去．