### PR TITLE
Fix test about tag, task_state and task_tag

### DIFF
--- a/app/models/task_state.rb
+++ b/app/models/task_state.rb
@@ -1,3 +1,6 @@
 class TaskState < ApplicationRecord
   has_many :tasks, dependent: :restrict_with_exception
+
+  validates :name, presence: true
+  validates :priority, presence: true
 end

--- a/test/fixtures/document_tags.yml
+++ b/test/fixtures/document_tags.yml
@@ -1,1 +1,5 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  document_id: 2
+  tag_id: 2

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,0 +1,6 @@
+document_has_tag:
+  id: 2
+  content: Document_has_tag
+  start_at: 2024-07-01 00:00:00
+  end_at: 2024-07-02 00:00:00
+  location: Test location

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -27,8 +27,9 @@ class TagTest < ActiveSupport::TestCase
   end
 
   test "should not delete tag which has document" do
-    skip ''
     tag = tags(:tag_has_document)
-    assert_not tag.destroy
+    assert_raises(ActiveRecord::DeleteRestrictionError) do
+      tag.destroy
+    end
   end
 end

--- a/test/models/task_state_test.rb
+++ b/test/models/task_state_test.rb
@@ -7,12 +7,10 @@ class TaskStateTest < ActiveSupport::TestCase
   end
 
   test "should not create task_state without name" do
-    skip ''
     assert_not TaskState.new(priority: 0).valid?
   end
 
   test "should not create task_state without priority" do
-    skip ''
     assert_not TaskState.new(name: "test").valid?
   end
 

--- a/test/models/task_tag_test.rb
+++ b/test/models/task_tag_test.rb
@@ -21,19 +21,19 @@ class TaskTagTest < ActiveSupport::TestCase
   end
 
   test "Should delete tag which has no tasks" do
-    skip ''
-    Task.create
-    Tag.create
+    Task.create(content: "test task")
+    Tag.create(name: "test tag")
     TaskTag.create(task_id: Task.last.id, tag_id: Tag.last.id)
-    Task.last.delete
-    assert TaskTag.last.destroy.valid?
+    Task.last.destroy
+    assert Tag.last.destroy
   end
 
   test "Should not delete tag which has tasks" do
-    skip ''
-    Task.create
-    Tag.create
+    Task.create(content: "test task")
+    Tag.create(name: "test tag")
     TaskTag.create(task_id: Task.last.id, tag_id: Tag.last.id)
-    assert TaskTag.last.destroy.invalid?
+    assert_raises(ActiveRecord::DeleteRestrictionError) do
+      Tag.last.destroy
+    end
   end
 end


### PR DESCRIPTION
## 概要
以下のテストについて正常に処理されるように修正．
+ tag_test.rb
  + should not delete tag which has document
+ task_state_test.rb
  + should not create task_state without name
  + should not create task_state without priority
+ task_tag_test.rb
  + Should delete tag which has no tasks
  + Should not delete tag which has tasks

## 変更点
+ should not delete tag which has document
  + 評価を「Tag が削除不可能か」から「Tag の削除を試みたときに特定の例外が発生するか」に変更．
  + テスト用の fixtures を追加．
+ should not create task_state without name
  + TaskState モデルの name について validation `presence: true` を追加．
+ should not create task_state without priority
  + TaskState モデルの priority について validation `presence: true` を追加．
+ Should delete tag which has no tasks
  + Task および Tag の create 時に必須項目を引数に追加．
  + Task の削除メソッドを delete から destroy に変更．
  + assert で削除結果を評価する対象を TaskTag ではなく Tag に変更．
+ Should not delete tag which has tasks
  + Task および Tag の create 時に必須項目を引数に追加．
  + 評価を「TaskTag が削除可能か」から「Tag の削除を試みたときに特定の例外が発生するか」に変更．