### PR TITLE
Fix modeltest about should not create user with_same_uid

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
     has_many :api_tokens, foreign_key: 'user_id'
     has_many :documents, foreign_key: 'creator_id'
     validates :screen_name, uniqueness: true
+    validates :uid, uniqueness: true 
 
     def User.digest(string)
         cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -78,7 +78,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not create user with_same_uid" do
-    skip ''
     user = @user_template.clone
     User.create(user)
     user[:name] ="other_name"


### PR DESCRIPTION
## 概要
以下のテストが通るようにテストの内容を修正した．
+ user_test.rb
  + should not create user with_same_uid

## 変更点
+ `user.rb`
   + `validates :uid, uniqueness: true` を追加し，`uid`属性の値が一意であるかどうかチェックするようにした．
+ `should not create user with_same_uid`
  + skip を消去した．