### PR TITLE
Fix 'should not create user without name' and 'should not create user without screen_name'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
     has_many :documents, foreign_key: 'creator_id'
     validates :screen_name, uniqueness: true
     validates :uid, uniqueness: true 
+    validates :name, presence: true
 
     def User.digest(string)
         cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
     validates :screen_name, uniqueness: true
     validates :uid, uniqueness: true 
     validates :name, presence: true
+    validates :screen_name, presence: true
 
     def User.digest(string)
         cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -19,7 +19,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not create user without name" do
-    skip ''
     user = @user_template.clone
     user[:name] = nil
     assert_not User.new(user).save

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -25,7 +25,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not create user without screen_name" do
-    skip ''
     user = @user_template.clone
     user[:screen_name] = nil
     assert_not User.new(user).save


### PR DESCRIPTION
## 概要
以下のtaskに関するテストを修正した．

1. name が設定されていない user が作成されないか確認するテスト
2. screen_name が設定されていない user が作成されないか確認するテスト
## 変更点
app/models/user.rb の User クラスにおいて，name および screen_name が空かどうかを判定するバリデーションを追加した．
