### PR TITLE
Fix 'should not create user without uid' test and 'should not create user with same name' test

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
     has_many :documents, foreign_key: 'creator_id'
     validates :screen_name, uniqueness: true
     validates :uid, uniqueness: true, presence: true
-    validates :name, presence: true
+    validates :name, presence: true, uniqueness: true
     validates :screen_name, presence: true
 
     def User.digest(string)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
     has_many :api_tokens, foreign_key: 'user_id'
     has_many :documents, foreign_key: 'creator_id'
     validates :screen_name, uniqueness: true
-    validates :uid, uniqueness: true 
+    validates :uid, uniqueness: true, presence: true
     validates :name, presence: true
     validates :screen_name, presence: true
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -37,7 +37,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not create user without uid" do
-    skip ''
     user = @user_template.clone
     user[:uid] = nil
     assert_not User.new(user).save

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -57,7 +57,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not create user with_same_name" do
-    skip ''
     user = @user_template.clone
     User.create(user)
     user[:screen_name] ="other_screen_name"


### PR DESCRIPTION
## 概要
以下のテストが通るようにuser.rbの内容を修正した．
1. should not create user without uid
2. should not create user with same name

## user.rbの変更点
2つのバリデーション処理を追加した．
1. uid要素が空かどうかを判定するバリデーション
2. 同じname要素がすでに存在するかどうかを判定するバリデーション