### PR TITLE
Fix bug of task creation from ActionItem in document

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -25,7 +25,7 @@
   <div class="markdown-body">
     <% desc = JayFlavoredMarkdownConverter.new(@document.description).content %>
     <% desc.each_line do |line| %>
-      <% matched = line.match(/--(>|&gt;)\(([^ ]+) !:([0-9]+)\)/) %>
+      <% matched = line.match(/--(>|&gt;)\(([^ ]+).* !:([0-9]+)\)/) %>
       <% if matched != nil %>
         <%== $` %>
         <% task_url = ActionItem.find_by(uid:matched[3].to_i)&.task_url %>
@@ -35,7 +35,7 @@
         <% else %>
           <% message = "Created from [AI#{matched[3]}](#{request.url.split('?').first}?ai=#{matched[3]})" %>
           <% if assigner != nil %>
-            <% assigner_id =  assigner.id %>
+            <% assigner_id = assigner.id %>
           <% end %>
           <%= link_to matched[0].html_safe, new_task_path(assigner_id: assigner_id, project_id: @document.project_id, desc_header: message) %>
         <% end %>
@@ -44,7 +44,7 @@
         <%== line %>
       <% end %>
     <% end %>
-    </div>
+  </div>
   </p>
   <%= link_to '編集', edit_document_path(@document) %>
 </div>


### PR DESCRIPTION
## 概要
文書内の ActionItem で人名以外が入っていると，タスクを作成できない問題に対処した．

## 原因
ActionItem の人名の部分にスペースが使用されていたためタスクを作成できなかった．
タスク作成のリンクを作成する文章を判定するために記述されている正規表現では人名に空白文字が存在することを許容していない．
この正規表現は app/views/documents/show.html.erb 内に記述されている．

## 変更点
人名を記述する箇所にスペースが含まれていても対応するように正規表現を変更した．
具体的には，これまでキャプチャしていた人名の部分の後ろに他の文字列が含まれていても正規表現が対応するようにした．
スペースなどを含めてキャプチャするような変更も考えられるが，これまでの運用と変更が少なくなるようにした．