### PR TITLE
Add auto update feature

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,17 @@
+name: create_release
+run-name: ${{ github.actor }} is creating release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  Create_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -152,3 +152,30 @@ rask の開発には docker-compose を使用する．
   ```
   $ systemctl start rask.service
   ```
+
+## 自動更新
+#### 概要
+* Rask に新たな Release が作成された際に自動更新できる．
+#### 手順
+1. `scripts/systemd_conf/rask-autoupdate.service` および `scripts/systemd_conf/rask-autoupdate.timer` を `/etc/systemd/system/` 以下にコピーする
+    ```bash
+    sudo cp scripts/systemd_conf/rask-autoupdate.* /etc/systemd/system/
+    ```
+2. 上記の2ファイルの内容を自身の環境に合わせて変更する
+    ```
+    # /etc/systemd/system/rask-autoupdate.service
+    - User=rask-user
+    + User=nomlab
+  
+    - ExecStart=/path/to/rask/script/update_rask.sh
+    + ExecStart=/home/nomlab/rask/scripts/update_rask.sh
+    ```
+    ```
+    # /etc/systemd/system/rask-autoupdate.timer
+    - OnCalendar=*-*-* 10:00:00
+    + OnCalendar=*-*-* 23:00:00
+    ```
+3. systemd の自動実行を有効にする
+    ```bash
+    sudo systemctl enable rask-autoupdate.timer
+    ```

--- a/scripts/autoupdate.sh
+++ b/scripts/autoupdate.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cd "$(dirname "$0")" || exit 1
+
+REPO_NAME="nomlab/rask"
+
+# Get current tag of this repository
+current_tag=$(git describe --tags --abbrev=0)
+
+# Get latest tag from GitHub
+latest_tag=$(curl  "https://api.github.com/repos/$REPO_NAME/releases/latest" | jq -r '.tag_name')
+
+# If the latest tag is newer than the current tag, update the Rask
+if [[ "$latest_tag" > "$current_tag" ]]; then
+    # Pull latest tag
+    git pull origin "$latest_tag"
+
+    # Update Rask image
+    ./script/setup-docker.sh "$USER"
+
+    # Stop Rask container and then Rask is restarted by systemd
+    ./rask-docker.sh stop
+fi
+

--- a/scripts/rask-docker.sh
+++ b/scripts/rask-docker.sh
@@ -8,7 +8,7 @@ DEFAULT_ATTACH_OPTION=it # {i|t|it|d}
 DEFAULT_PORT=3000 # host port which container binds
 DEFAULT_COMMAND="" # command which execute in container
                    # using default entrypoint of image, specify ""
-DEFAULT_IMAGE_NAME=rask
+DEFAULT_IMAGE_NAME=rask:$(git describe --tags --abbrev=0 || echo latest)
 DEFAULT_ENVIRONMENT=production
 # constant value
 SCRIPT_NAME=rask-docker.sh

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -76,7 +76,7 @@ function main() {
     echo "Creating Rask image"
     UID_SH=$(id -u $1)
     if ! docker buildx build \
-        -t rask \
+        -t rask:$(git describe --tags --abbrev=0 || echo latest) \
         -f scripts/docker/Dockerfile_production \
         --secret id=master-key,src=$PWD/config/master.key \
         --build-arg UID=$UID_SH .

--- a/scripts/systemd_conf/rask-autoupdate.service
+++ b/scripts/systemd_conf/rask-autoupdate.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Update Rask automatically
+
+[Service]
+Type=oneshot
+
+# Change this to the user that runs the Rask
+User=rask-user
+
+# Change this to the path to the Rask repository
+ExecStart=/path/to/rask/script/update_rask.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd_conf/rask-autoupdate.timer
+++ b/scripts/systemd_conf/rask-autoupdate.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Trigger Rask updater
+
+[Timer]
+Persistent=true
+
+# Change the time for your needs
+OnCalendar=*-*-* 10:00:00
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## やったこと
Rask を自動更新するためのスクリプト，および systemd 用のサービスファイルを追加した．

## 使用方法
変更した README を参照のこと．

## 仕組み
1. GitHub に "v" から始まる Tag を push すると GitHub Actions により，自動で Release が作成される．
2. 本番環境上で Systemd Timer により autoupdate.sh が定期実行される．
    上記スクリプトは以下の作業により，Rask を更新する．
    1. 現在のレポジトリの最新タグより，GitHub上の最新 Release の方が新しい場合，以下の更新作業を行う．
    2. リモートレポジトリの 最新 Tag を pull する．
    3. Rask の Image を更新する．
    4. Rask のコンテナを止めることで，systemd に Rask を再起動してもらう．
