### PR TITLE
Fix model test about should not delete user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,11 @@ class User < ApplicationRecord
     validates :name, presence: true, uniqueness: true
     validates :screen_name, presence: true
 
+    before_destroy :prevent_destroy
+     def prevent_destroy
+       throw(:abort)
+     end
+
     def User.digest(string)
         cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                  BCrypt::Engine.cost

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,11 +21,11 @@ class User < ApplicationRecord
     validates :uid, uniqueness: true, presence: true
     validates :name, presence: true, uniqueness: true
     validates :screen_name, presence: true
-
+# This software is for small groups, so users cannot be deleted
     before_destroy :prevent_destroy
-     def prevent_destroy
-       throw(:abort)
-     end
+    def prevent_destroy
+      throw(:abort)
+    end
 
     def User.digest(string)
         cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -81,7 +81,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "should not delete user" do
-    skip ''
     user = @user_template.clone
     user = User.create(user)
     assert_not user.destroy

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -79,7 +79,7 @@ class UserTest < ActiveSupport::TestCase
     user[:screen_name] ="other_screen_name"
     assert_not User.new(user).save
   end
-
+# This software is for small groups, so users cannot be deleted
   test "should not delete user" do
     user = @user_template.clone
     user = User.create(user)


### PR DESCRIPTION
## 概要
以下のテストが通るようにテストの内容を修正した．
+ user_test.rb
  + should not delete user

## 変更点
+ `user.rb`
   + User モデルに `before_destroy` コールバックを追加し、削除を防ぐようにした．
+ `should not create user with_same_uid`
  + skip を消去した．