### PR TITLE
Review and update actionitems test

### DIFF
--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,9 +1,8 @@
 class ActionItem < ApplicationRecord
-  before_create :check_varid_id
-  before_create :set_uid
+  after_create :set_uid
   validates :task_url, format: { with: /\A[a-zA-Z0-9\-._~:\/?#\[\]@!$&'()*+,;%=]+\z/}, allow_nil: true
   validates :uid, uniqueness: true
-  before_update :check_uid_readonly
+  before_update :prevent_uid_change
 
   def uid
     "%04d" % self.id
@@ -11,19 +10,14 @@ class ActionItem < ApplicationRecord
 
   private
 
-  def check_varid_id
-    if self.id > 9999 || self.id < 1 
-      throw(:abort)
-    end
-  end
-
   def set_uid
-    self.uid = uid
+    self.update(uid: uid)
   end
 
-  def check_uid_readonly
-    if uid_changed?
+  def prevent_uid_change
+    if self.uid_was.present? && self.uid_changed?
       throw(:abort)
     end
   end
+
 end

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,5 +1,9 @@
 class ActionItem < ApplicationRecord
-  after_create :set_uid
+  before_create :check_varid_id
+  before_create :set_uid
+  validates :task_url, format: { with: /\A[a-zA-Z0-9\-._~:\/?#\[\]@!$&'()*+,;%=]+\z/}, allow_nil: true
+  validates :uid, uniqueness: true
+  before_update :check_uid_readonly
 
   def uid
     "%04d" % self.id
@@ -7,7 +11,19 @@ class ActionItem < ApplicationRecord
 
   private
 
+  def check_varid_id
+    if self.id > 9999 || self.id < 1 
+      throw(:abort)
+    end
+  end
+
   def set_uid
-    self.update(uid: uid)
+    self.uid = uid
+  end
+
+  def check_uid_readonly
+    if uid_changed?
+      throw(:abort)
+    end
   end
 end

--- a/test/fixtures/action_items.yml
+++ b/test/fixtures/action_items.yml
@@ -1,7 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
+  uid: "0001"
   task_url: /1
 
 two:
-  task_url: /1
+  id: 2
+  uid: "0002"
+  task_url: /2

--- a/test/fixtures/action_items.yml
+++ b/test/fixtures/action_items.yml
@@ -7,5 +7,9 @@ one:
 
 two:
   id: 2
-  uid: "0002"
   task_url: /2
+
+three:
+  id: 3
+  uid: "0003"
+  task_url: /3

--- a/test/models/action_item_test.rb
+++ b/test/models/action_item_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ActionItemTest < ActiveSupport::TestCase
   test "Should create with correct data" do
     id = ActionItem.maximum(:id).to_i.next
-    assert ActionItem.new(id: 10000, task_url: '/github.com').save
+    assert ActionItem.new(id: id, task_url: '/github.com').save
   end
 
   test "Should create action_item without task_url" do
@@ -14,8 +14,7 @@ class ActionItemTest < ActiveSupport::TestCase
   test "Should be existed uid to created action_item" do
     id = ActionItem.maximum(:id).to_i.next
     ActionItem.new(id: id).save
-    item = ActionItem.find(id)
-    assert item.uid.present?
+    assert ActionItem.find(id).uid.present?
   end
 
   test "Should be added task_url to created action_item" do
@@ -26,7 +25,11 @@ class ActionItemTest < ActiveSupport::TestCase
     assert ActionItem.last.destroy
   end
 
-  test "Should not update uid" do
+  test "Should be updated uid from nil to anything" do
+    assert ActionItem.find(2).update(uid: 2)
+  end
+
+  test "Should not update uid from anything to anything" do
     assert_not ActionItem.last.update(uid: 1)
   end
 

--- a/test/models/action_item_test.rb
+++ b/test/models/action_item_test.rb
@@ -2,39 +2,35 @@ require "test_helper"
 
 class ActionItemTest < ActiveSupport::TestCase
   test "Should create with correct data" do
-    assert ActionItem.new.valid?
+    id = ActionItem.maximum(:id).to_i.next
+    assert ActionItem.new(id: 10000, task_url: '/github.com').save
   end
 
-  test "Should be added uid to created action_item" do
-    ActionItem.create
-    assert ActionItem.last.uid.present?
+  test "Should create action_item without task_url" do
+    id = ActionItem.maximum(:id).to_i.next
+    assert ActionItem.new(id: id).save
+  end
+
+  test "Should be existed uid to created action_item" do
+    id = ActionItem.maximum(:id).to_i.next
+    ActionItem.new(id: id).save
+    item = ActionItem.find(id)
+    assert item.uid.present?
   end
 
   test "Should be added task_url to created action_item" do
-    ActionItem.create
-    assert ActionItem.last.save(task_url: '/test')
+    assert ActionItem.last.update(task_url: '/localhost:3000')
   end
 
   test "Should delete action_item" do
-    ActionItem.create
     assert ActionItem.last.destroy
   end
 
-  test "Should not update uid that is added once" do
-    skip ''
-    ActionItem.create
-    assert_not ActionItem.last.update(uid: -1)
-  end
-
-  test "Should not update uid with uid already exists" do
-    skip ''
-    ActionItem.create
-    assert_not ActionItem.last.update(uid: ActionItem.first.uid)
+  test "Should not update uid" do
+    assert_not ActionItem.last.update(uid: 1)
   end
 
   test "Should not update task_url with string other than URL" do
-    skip ''
-    ActionItem.create
-    assert_not ActionItem.last.save(task_url: '#This is not url#')
+    assert_not ActionItem.last.update(task_url: '#This is not url#')
   end
 end


### PR DESCRIPTION
# 概要
+ ActionItemに関するモデルテストを再検討し，修正した
  + uid は id とリンクしているため，一度追加された uid を更新できない仕様 (read only) にした．
  + uid は create された id を用いて update する形でテーブルに追加されているため，uid を null からは更新できるようにし，それ以外の状態から更新しようとしたときエラーが出るようにした．
+ 各スキーマに関してvaridate を追加した．
  + task_url を正規表現を用いてURLパターンにマッチするか判別し，nil を許容した．
  + uid に一意性をもたせた．