### PR TITLE
Review and update ActionItem test

### DIFF
--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,5 +1,8 @@
 class ActionItem < ApplicationRecord
   after_create :set_uid
+  validates :task_url, format: { with: /\A[a-zA-Z0-9\-._~:\/?#\[\]@!$&'()*+,;%=]+\z/}, allow_nil: true
+  validates :uid, uniqueness: true
+  before_update :prevent_uid_change
 
   def uid
     "%04d" % self.id
@@ -10,4 +13,11 @@ class ActionItem < ApplicationRecord
   def set_uid
     self.update(uid: uid)
   end
+
+  def prevent_uid_change
+    if self.uid_was.present? && self.uid_changed?
+      throw(:abort)
+    end
+  end
+
 end

--- a/test/fixtures/action_items.yml
+++ b/test/fixtures/action_items.yml
@@ -1,7 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
+  uid: "0001"
   task_url: /1
 
 two:
-  task_url: /1
+  id: 2
+  task_url: /2
+
+three:
+  id: 3
+  uid: "0003"
+  task_url: /3

--- a/test/models/action_item_test.rb
+++ b/test/models/action_item_test.rb
@@ -2,39 +2,38 @@ require "test_helper"
 
 class ActionItemTest < ActiveSupport::TestCase
   test "Should create with correct data" do
-    assert ActionItem.new.valid?
+    id = ActionItem.maximum(:id).to_i.next
+    assert ActionItem.new(id: id, task_url: '/github.com').save
   end
 
-  test "Should be added uid to created action_item" do
-    ActionItem.create
-    assert ActionItem.last.uid.present?
+  test "Should create action_item without task_url" do
+    id = ActionItem.maximum(:id).to_i.next
+    assert ActionItem.new(id: id).save
+  end
+
+  test "Should be existed uid to created action_item" do
+    id = ActionItem.maximum(:id).to_i.next
+    ActionItem.new(id: id).save
+    assert ActionItem.find(id).uid.present?
   end
 
   test "Should be added task_url to created action_item" do
-    ActionItem.create
-    assert ActionItem.last.save(task_url: '/test')
+    assert ActionItem.last.update(task_url: '/localhost:3000')
   end
 
   test "Should delete action_item" do
-    ActionItem.create
     assert ActionItem.last.destroy
   end
 
-  test "Should not update uid that is added once" do
-    skip ''
-    ActionItem.create
-    assert_not ActionItem.last.update(uid: -1)
+  test "Should be updated uid from nil to anything" do
+    assert ActionItem.find(2).update(uid: 2)
   end
 
-  test "Should not update uid with uid already exists" do
-    skip ''
-    ActionItem.create
-    assert_not ActionItem.last.update(uid: ActionItem.first.uid)
+  test "Should not update uid from anything to anything" do
+    assert_not ActionItem.last.update(uid: 1)
   end
 
   test "Should not update task_url with string other than URL" do
-    skip ''
-    ActionItem.create
-    assert_not ActionItem.last.save(task_url: '#This is not url#')
+    assert_not ActionItem.last.update(task_url: '#This is not url#')
   end
 end


### PR DESCRIPTION
# 概要
+ ActionItemに関するモデルテストを再検討し，修正した
  + uid は id とリンクしているため，一度追加された uid を更新できない仕様 (read only) にした．
  + uid は create された id を用いて update する形でテーブルに追加されているため，uid を null からは更新できるようにし，それ以外の状態から更新しようとしたときエラーが出るようにした．
+ 各スキーマに関してvaridate を追加した．
  + task_url を正規表現を用いてURLパターンにマッチするか判別し，nil を許容した．
  + uid に一意性をもたせた．