### PR TITLE
Fix Controllers test

### DIFF
--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -56,7 +56,6 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update task" do
-    skip ''
     log_in_as(@user)
     patch task_url(@task), params: { task: { content: @task.content, creator_id: @task.creator_id, task_state_id: @task.task_state_id } }
     assert_redirected_to tasks_url

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -24,7 +24,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit" do
-    skip ''
     log_in_as(@user)
     get edit_user_url(@user)
     assert_response :success
@@ -36,7 +35,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update user" do
-    skip ''
     log_in_as(@user)
     patch user_url(@user), params: { user: { name: @user.name } }
     assert_redirected_to user_url(@user)
@@ -47,18 +45,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to welcome_path
   end
 
-  test "should destroy user" do
-    skip ''
+  test "should not destroy user" do
     log_in_as(@user)
-    assert_difference('User.count', -1) do
+    assert_no_difference("User.count") do
       delete user_url(@user)
     end
-
-    assert_redirected_to projects_url
-  end
-
-  test "should redirect destroy to login" do
-    delete user_url(@user)
-    assert_redirected_to welcome_path
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,15 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  screen_name: MyString1
-  avatar_url: hoge
+  name: Test User1
+  screen_name: test-user1
+  avatar_url: http://example.com/user1
   provider: github
   uid: 1
 
 two:
-  name: MyString
-  screen_name: MyString2
-  avatar_url: hoge
+  name: Test User2
+  screen_name: test-user2
+  avatar_url: http://example.com/user2
   provider: github
   uid: 2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ class ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:github] =
       OmniAuth::AuthHash.new({
                                :provider => 'github',
-                               :uid => user.id,
+                               :uid => user.uid,
                                :credentials => {
                                  :token => 'mock_token',
                                  :active_member => 'mock_active_member'


### PR DESCRIPTION
Controllers test の失敗していたテストを修正した．

具体的には， `test/test_helper.rb` 内の OmniAuth mock 作成時に，`uid` に `user.id` ではなく `user.uid` を指定することでほとんどのテストが成功した．(それでもなお失敗したテストについては後述する)
失敗までの流れを以下に示す．
1. ログインしたいユーザ(例 id: 1, uid: 10)で test login したとき， mock の uid に 1 が保存される．
1. `SessionsController` の `create` 時に以下のコードが走る．
      `user = User.find_by_provider_and_uid(auth["provider"], auth["uid"]) || User.create_with_omniauth(auth)`
1. `User.find_by_provider_and_uid` で，uid が 1 のエントリを検索するが，存在しないため，新たなユーザを作成する．
1. 作成された新規ユーザの id を `session[:user_id]` に保存する．
1.  `current_user?` で，ログインしたいユーザと新規ユーザの id を比較し，false が返ってくる．
1. ログインに失敗し，テストも失敗する．

上記変更でも失敗していた `should destroy user` について
+ 以前の議論で，ユーザは基本的に削除しない方針になったため，model 側で destroy を無視するよう設定されている．
+  そのため，`should_destroy_user` を含めたユーザ削除の成功を期待するテストを削除した．
+ 代わりに，ユーザ削除の失敗を期待するテスト `should_not_destroy_user` を追加した．

