### PR TITLE
Fixes a problem that when creating a new document, a task is created

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -26,7 +26,7 @@
     <% end %>
   </div>
 
-  <%= link_to '新規作成', new_task_path, class: "btn btn-danger ms-3" %>
+  <%= link_to '新規作成', new_document_path, class: "btn btn-danger ms-3" %>
 </div>
 
 <%= render @documents %>


### PR DESCRIPTION
## 修正点
文書一覧のページから文書新規作成すると，タスクの新規作成ページに遷移していた．
そのため，遷移先を文書の新規作成ページに遷移するように変更した．