### PR TITLE
Hotfix stop validating uid

### DIFF
--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,7 +1,7 @@
 class ActionItem < ApplicationRecord
   after_create :set_uid
   validates :task_url, format: { with: /\A[a-zA-Z0-9\-._~:\/?#\[\]@!$&'()*+,;%=]+\z/}, allow_nil: true
-  validates :uid, uniqueness: true
+  # validates :uid, uniqueness: true
   before_update :prevent_uid_change
 
   def uid


### PR DESCRIPTION
uid の uniqness を validate する際に uid を計算してしまうが，その時点で self.id はまだ 確定していない (nil) ので，uid メソッド内で nil を数に変換しようとして落ちる．

とりあえず commentout した．
