### PR TITLE
Changed the sorting method of tasks

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,19 +15,19 @@ class TasksController < ApplicationController
   def sort_check(param)
     if param.present?
       sort_column = []
-      sort_column << "task_state_id ASC" << param
+      sort_column << "state_priority DESC" << param
     else
-      "task_state_id ASC"
+      "state_priority DESC"
     end
   end
 
   # GET /tasks or /tasks.json
   def index
     if params[:q].nil?
-      @q = Task.ransack(params[:q])
-      @q.sorts = "task_state_id ASC"
+      @q = Task.joins(:state).ransack(params[:q])
+      @q.sorts = ["state_priority DESC", "due_at ASC"]
     else
-      @q = Task.ransack({combinator: 'and', groupings: search_check(params[:q][:content_or_assigner_screen_name_or_description_or_project_name_cont])})
+      @q = Task.joins(:state).ransack({combinator: 'and', groupings: search_check(params[:q][:content_or_assigner_screen_name_or_description_or_project_name_cont])})
       @q.sorts = sort_check(params[:q][:s])
     end
     @tasks = @q.result.page(params[:page]).per(50).includes(:user, :state)

--- a/app/models/task_state.rb
+++ b/app/models/task_state.rb
@@ -3,4 +3,8 @@ class TaskState < ApplicationRecord
 
   validates :name, presence: true
   validates :priority, presence: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    [ "priority" ]
+  end
 end


### PR DESCRIPTION
### 変更点
タスクのソート方法について以下の変更を行いました．

1. 期限順でソートした際に， `task_state` テーブルの `priority`(0: done, 1: todo, 2: draft) でソートし，同一の`priority` の場合，`task` テーブルの `due_at` でソートするように変更した．
2.  期限順以外のソートでも先に`priority`でソートし，同一`priority`の中で選択した項目のソートを行うように変更した．
3. クエリが`nil`の場合，1の降順がデフォルトで行われて表示されるようにした．