### PR TITLE
Update JavaScript about SHUKUDAI_NOTATION to support importmap

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "documents"

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -48,4 +48,4 @@
   </p>
   <%= link_to '編集', edit_document_path(@document), class: "text-black text-decoration-none" %>
 </div>
-<%= javascript_include_tag 'documents' %>
+

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,3 +10,4 @@ pin "eventemitter3" # @2.0.3
 pin "textarea-caret" # @3.1.0
 pin "undate/lib/update", to: "undate--lib--update.js" # @0.2.4
 pin "tag_completion"
+pin "documents", to: "documents.js"


### PR DESCRIPTION
## やったこと
+ 宿題記法に関する JavaScript を importmap に対応させた

## 背景
+ rails 7 に移行した際，宿題記法からタスクを作成した際に内容が自動入力される機能が使えなくなった
+ importmap への移行が不十分であったことが原因だったため対応させる

## 変更点
+ `app/javascript/application.js` を更新した
  + `import "documents"` を追加した
    + `app/javascript` 配下の `documents.js` をimport する設定を書き込んだ
+ `config/importmap.rb` を更新した
  + `pin "documents", to: "documents.js"` を追加した
    + `import "documents"` の `documents` と `documents.js` を対応させた
+ `app/views/documents/show.html.erb` を更新した
  + importmapでは `app/views/layout/application.rb` に `<%= javascript_importmap_tags %>` として，importmap を用いるすべての JavaScript を読み込む記述がある
  + そのため，`<%= javascript_include_tag 'documents' %>` を削除した
+ `app/javascript/documents.js` を更新した
  + jquery が利用できなくなっていたため，JavaScript の `getElementById`の記法に変更した
