### PR TITLE
Improve display of tasks and document lists

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,12 +1,12 @@
 .overdue_mark{
-  color: #f00;
-  font-size: 18px;
+  color: rgb(230, 75, 75);
+  font-size: 14px;
   text-align: right;
 }
 
 .ongoing_mark{
-  color: #008000;
-  font-size: 18px;
+  color: #1c501c;
+  font-size: 14px;
   text-align: right;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def tag_label(tag)
-    raw %(<span class="inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"> #{tag.name}</span>)
+    raw %(<span class="inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-0 rounded"> #{tag.name}</span>)
   end
 end

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,31 +1,38 @@
 <div class="p-3 my-3 border rounded d-flex justify-content-between align-items-center">
   <div class="flex-grow-1">
     <p class="h5 mb-2">
-      <%= link_to document.content, document, class: "text-black" %>
+      <%= link_to document.content.truncate(20), document, class: "text-black text-small" %>
     </p>
     <p class="mb-1">
-      <p>開始日: <%= document.start_at&.strftime('%Y/%m/%d') %></p>
-      <p>場所: <%= document.location %></p>
-      <p>作成者: <%= link_to_if document.creator&.screen_name, document.creator&.name, document.creator, class: "text-black text-decoration-none" %></p>
-      <p class="mt-2">
-      <% document.tags.each do |tag| %>
-        <%= link_to tag_label(tag), tag, class: "btn btn-primary btn-outline-primary btn-lg" %>
-      <% end %>
-      </p>
+      <%= link_to_if document.creator&.screen_name, document.creator&.name, document.creator, class: "text-black text-decoration-none" %>
+      ,
+      <span class="text-black"><%= document.start_at&.strftime('%Y/%m/%d') %></span>
+      <span class="mt-2">
+        <% document.tags.each do |tag| %>
+          <%= link_to tag.name, tag, class: "text-orange fw-bold badge" %>
+        <% end %>
+      </span>
     </p>
   </div>
 
   <% if logged_in? %>
     <div class="d-flex gap-2">
-      <%= link_to '詳細', document, class: "btn btn-sm" %>
       <%= link_to '編集', edit_document_path(document), class: "btn btn-sm" %>
-      <%= button_to '削除', document, method: :delete, data: { turbo_confirm: 'この文書を削除しますか？' }, class: "btn btn-sm" %>
     </div>
   <% end %>
 </div>
 
 <style>
-  .text-black {
+  .text-black, .badge {
     text-decoration: none;
+  }
+  .text-orange, .badge {
+    color: #f59e0b;
+    font-size: 0.8rem;
+    text-decoration: none;
+  }
+  .text-small {
+    font-size: 1.1rem;
+    font-weight: normal;
   }
 </style>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -46,6 +46,9 @@
     <% end %>
   </div>
   </p>
-  <%= link_to '編集', edit_document_path(@document), class: "text-black text-decoration-none" %>
+  <div class="d-flex gap-2">
+    <%= link_to '編集', edit_document_path(@document), class: "btn btn-outline-dark" %>
+    <%= button_to '削除', @document, method: :delete, data: { turbo_confirm: 'この文書を削除しますか？' }, class: "btn btn-outline-dark" %>
+  </div>
 </div>
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -10,38 +10,14 @@
     <p class="h5 fw-bold mb-2">タスク一覧</p>
     <div class="flex-grow-1"></div>
   </div>
-  <% @tag.tasks.each do |task| %>
-    <div class="p-3 my-3 border rounded d-flex justify-content-between">
-      <div>
-        <p class="h5"><%= task.content %></p>
-        <p>担当者: <%= link_to task.assigner.name, task.assigner %></p>
-      </div>
-      <div class="flex-grow-1"></div>
-      <% if logged_in? %>
-        <%= link_to '詳細', task, class: "btn btn-sm" %>
-        <%= link_to '編集', edit_task_path(task), class: "btn btn-sm" %>
-        <%= button_to '削除', task, method: :delete, data: { turbo_confirm: 'このタスクを削除しますか？' }, class: "btn btn-sm" %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render @tag.tasks %>
 
   <div class="d-flex">
-    <p class="h5 fw-bold mb-2">文書一覧</p>
+    <p class="h5 fw-bol,dfrom_tag_partial: true  mb-2">文書一覧</p>
     <div class="flex-grow-1"></div>
   </div>
-  <% @tag.documents.each do |document| %>
-    <div class="p-3 my-3 border rounded d-flex justify-content-between">
-      <div>
-        <p class="h5"><%= document.content %></p>
-      </div>
-      <div class="flex-grow-1"></div>
-      <% if logged_in? %>
-        <%= link_to '詳細', document, class: "btn btn-sm" %>
-        <%= link_to '編集', edit_document_path(document), class: "btn btn-sm" %>
-        <%= button_to '削除', document, method: :delete, data: { turbo_confirm: 'この文書を削除しますか？' }, class: "btn btn-sm" %>
-      <% end %>
-    </div>
-  <% end %>
+
+  <%= render @tag.documents, from_tag_partial: true %>
 
   <%= link_to '編集', edit_tag_path(@tag), class: "btn btn-sm" %>
 </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -14,39 +14,44 @@
           <% end %>
         </span>
       <% end %>
-      <%= link_to task.content, task, class: "text-black" %>
+      <%= link_to task.content.truncate(20), task, class: "text-black text-small" %>
     </div>
+
     <p class="mb-1">
       <% if task.project %>
         <%= link_to task.project.name, task.project, class: "text-black" %>
       <% end %>
       <%= link_to task.assigner.name, task.assigner, class: "text-black" %>
+      ,
       <span class="text-black"><%= task.show_days_ago.round.to_s + "日前" %></span>
       <% task.tags.each do |tag| %>
-        <%= link_to tag_label(tag), tag, class: "btn btn-primary btn-outline-primary btn-lg" %>
+        <%= link_to tag.name, tag, class: "text-orange fw-bold badge" %>
       <% end %>
     </p>
   </div>
 
   <div class="text-center">
-    <% if task.overdue? %>
-      <p class="overdue_mark">期限切れです！</p>
-    <% else %>
-      <p class="ongoing_mark"><%= days_to_deadline_as_string task %></p>
+    <%unless task.completed? %>
+      <% if task.overdue? %>
+        <p class="overdue_mark">期限切れです！</p>
+      <% else %>
+        <p class="ongoing_mark"><%= days_to_deadline_as_string task %></p>
+      <% end %>
     <% end %>
   </div>
-
-  <% if logged_in? %>
-    <div class="d-flex gap-2">
-      <%= link_to '詳細', task, class: "btn btn-sm" %>
-      <%= link_to '編集', edit_task_path(task), class: "btn btn-sm" %>
-      <%= button_to '削除', task, method: :delete, data: { turbo_confirm: 'このタスクを削除しますか？' }, class: "btn btn-sm" %>
-    </div>
-  <% end %>
 </div>
 
 <style>
-  .text-black {
+  .text-black, .badge {
     text-decoration: none;
+  }
+  .text-orange, .badge {
+    color: #f59e0b;
+    font-size: 0.8rem;
+    text-decoration: none;
+  }
+  .text-small {
+    font-size: 1.1rem;
+    font-weight: normal;
   }
 </style>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -30,4 +30,10 @@
   <%= link_to @task.project.name, @task.project, class: "text-dark text-decoration-none" if @task.project %>
 </div>
 
-<%= link_to '編集', edit_task_path(@task), class: "btn btn-outline-dark" %>
+
+<% if logged_in? %>
+  <div class="d-flex gap-2">
+    <%= link_to '編集', edit_task_path(@task), class: "btn btn-outline-dark" %>
+    <%= button_to '削除', @task, method: :delete, data: { turbo_confirm: 'このタスクを削除しますか？' }, class: "btn btn-outline-dark" %>
+  </div>
+<% end %>


### PR DESCRIPTION
## やったこと
+ タスク，文書一覧の表示を改善した
## 背景
+ 2025/7/18時点での Rask は，以下2つのような理由から，タグで絞った際のタスク，文書一覧の見た目が良くない
 1. タスク一覧では，タスクのタイトルと担当者しか表示されない
 2. 文書一覧では，文書のタイトルしか表示されない
+ そこで，そこで，タグで絞った際の一覧表示を改善する
+ また，タスク，文書一覧の表示についても改めて見直し，改善する

## 変更点
 1. タスクで絞ったタスク・文書を，それぞれの一覧と同じ表示に統一した
 + `app/views/tags/show.html.erb` から読み込むパーシャルを変更．

 2. 期限までの日数の表示が派手なため，見やすくした
 + `rask/app/assets/stylesheets/tasks.scss` を変更．文字のサイズを小さくして，色を変更した．

 3. タスク画面で各タスクについて詳細，編集，削除と表示されているが，タスク名をクリックすれば詳細が開くため消した．
+ `app/views/tasks/_task.html.erb`，`app/views/tasks/show.html.erb` を変更．
+ 文書画面については，編集ボタンのみ残した．これにあたり，`app/views/documents/_document.html.erb`，`app/views/documents/show.html.erb` を変更．

 4. タスクのタイトルの文字サイズが大きく見にくいため，いい感じのサイズに変更した
+ 文字のサイズを小さくするための，`.text-small`クラスを定義し，`app/views/tasks/_task.html.erb`のタスクタイトルを表示するタグに，そのクラスを適用
+ ドキュメントの方も同様の修正を行った
 5. タスク・文書一覧のタイトルが長い場合，「タスク名〜...」のように表示されるようにした
+ `app/views/tasks/_task.html.erb`，`app/views/documents/_document.html.erb`それぞれで`truncate`を用いた．

6. タスク・文書一覧の開始日や作成者などの情報を見やすくした
+ 名前，開始日を1行にまとめた．
+ `app/views/tasks/_task.html.erb`，`app/views/tasks/show.html.erb` を変更．

7. 文書やタスクの一覧画面で各項目について表示されるタグのサイズを改善した
+ タグサイズを小さくした．また，アイコン形式のタグではなく，文字を太字にし，オレンジ色にした．
+ `app/views/tasks/_task.html.erb`，`app/views/tasks/show.html.erb` を変更．

8. 完了したタスクについて期限の項目が表示されないようにした
  + `app/views/tasks/_task.html.erb` において，期限を表示する部分をtaskがcompletedではない場合のみ表示するように変更した
