### PR TITLE
feat: add filter for displaying only todo tasks and update task displ…

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -31,6 +31,10 @@ class TasksController < ApplicationController
       @q.sorts = sort_check(params[:q][:s])
     end
     @tasks = @q.result.page(params[:page]).per(50).includes(:user, :state)
+
+    return unless params[:only_todo] == '1'
+
+    @tasks = @tasks.where(task_state_id: TaskState.find_by(name: 'todo').id)
   end
 
   # GET /tasks/1 or /tasks/1.json

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,4 +1,4 @@
-<div class="p-3 my-3 border rounded d-flex justify-content-between align-items-center">
+<div class="p-3 my-3 border rounded d-flex justify-content-between align-items-center <%= 'opacity-50' if task.completed? %>">
   <div class="flex-grow-1">
     <div class="h5 mb-2">
       <%= turbo_frame_tag "task_#{task.id}" do %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -29,6 +29,13 @@
   <%= link_to '新規作成', new_task_path, class: "btn btn-danger ms-3" %>
 </div>
 
+<%= form_with url: request.path, method: :get, local: true, html: { class: "d-flex" } do %>
+      <%= check_box_tag :only_todo, "1", params[:only_todo] == "1", onchange: "this.form.submit()" %>
+    <div class="mx-1">
+      todoのみ
+    </div>
+<% end %>
+
 <%= render @tasks %>
 
 <div class="row">


### PR DESCRIPTION
## トグル表示
- タスク一覧画面に，チェックボックスを追加し，todo のタスクのみを表示できる様にした．
<img width="1351" height="726" alt="image" src="https://github.com/user-attachments/assets/cd1f063f-4b5e-4fe5-b63c-f644038e104b" />

## グレーアウト
- done のタスクはグレーアウトするように変更した．
<img width="1331" height="893" alt="image" src="https://github.com/user-attachments/assets/c675a122-29a1-404d-ad4a-06c6aefe01a9" />
