### PR TITLE
Add uid and screen_name fields to user creation task

### DIFF
--- a/lib/tasks/create_user.rake
+++ b/lib/tasks/create_user.rake
@@ -5,7 +5,9 @@ namespace :create_user do
     User.create!(
       name:     args.name,
       password: args.password,
-      provider: "local"
+      provider: "local",
+      uid: SecureRandom.hex(10),
+      screen_name: args.name,
     )
     puts "#{args.name}を作成しました。"
   end


### PR DESCRIPTION
## 概要
ユーザアカウントを生成するタスク `create_user.rake` で，ユーザが作成できない問題が起きていた．
原因は，User モデルは `provider`，`uid` 属性が必須だが，ユーザ作成時に，デフォルトの値を設定していなかったこと．

## 変更点
create_user.rake で，`provider`，`uid` 属性のデフォルト値を与えるように変更した．
`screen_name` 属性についても，`name` と同様に引数から与えるように変更した．