### PR TITLE
Refactor user show view to display API tokens conditionally and remov…

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   # GET /users/1 or /users/1.json
   def show
-    @api_tokens = @user == current_user ? @user.api_tokens : []
+    @api_tokens = current_user?(@user) ? @user.api_tokens : []
     @assigned_tasks = @user.assigned_tasks.active.desc(5)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   # GET /users/1 or /users/1.json
   def show
-    @api_tokens = ApiToken.all
+    @api_tokens = @user == current_user ? @user.api_tokens : []
     @assigned_tasks = @user.assigned_tasks.active.desc(5)
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,7 +16,7 @@
   <%= link_to "タスク一覧へ", tasks_path, method: :get, class: "text-muted text-decoration-none" %>
 </div>
 
-<% if @user == current_user %>
+<% if logged_in? && current_user?(@user) %>
   <div>
     <p class="h4 font-weight-bold mb-2">APIトークン</p>
     <% @api_tokens.each do |api_token| %>
@@ -25,8 +25,6 @@
           <p>APIトークン: <%= api_token.secret %></p>
           <p>トークン名: <%= api_token.description %></p>
           <p>有効期限: <%= api_token.expired_at %></p>
-        </div>
-        <div>
         </div>
         <%= link_to '編集', edit_api_token_path(api_token), class: "btn btn-sm" %>
         <%= button_to '削除', api_token, method: :delete, data: { turbo_confirm: 'このAPIトークンを削除しますか？' }, class: "btn btn-sm" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,12 +2,12 @@
 
 <div class="my-3">
   <p class="h4 font-weight-bold mb-2">氏名</p>
-  <%= link_to @user.name, user_path(@user), class: "text-muted text-decoration-none" %>
+  <%= @user.name %>
 </div>
 
 <div class="my-3">
   <p class="h4 font-weight-bold mb-2">アカウント名</p>
-  <%= link_to @user.screen_name, user_path(@user), class: "text-muted text-decoration-none" %>
+  <%= @user.screen_name %>
 </div>
 
 <div class="my-3">
@@ -16,10 +16,10 @@
   <%= link_to "タスク一覧へ", tasks_path, method: :get, class: "text-muted text-decoration-none" %>
 </div>
 
-<div>
-  <p class="h4 font-weight-bold mb-2">APIトークン</p>
-  <% @api_tokens.each do |api_token| %>
-    <% if api_token.user_id == current_user.id %>
+<% if @user == current_user %>
+  <div>
+    <p class="h4 font-weight-bold mb-2">APIトークン</p>
+    <% @api_tokens.each do |api_token| %>
       <div class="p-3 my-3 border rounded d-flex justify-content-between">
         <div>
           <p>APIトークン: <%= api_token.secret %></p>
@@ -32,7 +32,7 @@
         <%= button_to '削除', api_token, method: :delete, data: { turbo_confirm: 'このAPIトークンを削除しますか？' }, class: "btn btn-sm" %>
       </div>
     <% end %>
-  <% end %>
-</div>
+  </div>
+<% end %>
 
 <%= link_to '編集', edit_user_path(@user), class: "btn btn-sm" %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -51,4 +51,33 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       delete user_url(@user)
     end
   end
+
+  test "should not show own api tokens when viewing other user's page" do
+    user_a = users(:one)
+    user_b = users(:two)
+    log_in_as(user_a)
+    
+    get user_url(user_b)
+    assert_response :success
+    
+    # ユーザーAのAPIトークンのsecretが表示されていないことを確認
+    assert_not_includes @response.body, api_tokens(:one).secret
+    
+    # ユーザーBのAPIトークンのsecretも表示されていないことを確認
+    assert_not_includes @response.body, api_tokens(:two).secret
+  end
+
+  test "should show own api tokens on own user page" do
+    user_a = users(:one)
+    log_in_as(user_a)
+    
+    get user_url(user_a)
+    assert_response :success
+    
+    # ユーザーAのAPIトークンのsecretが表示されていることを確認
+    assert_includes @response.body, api_tokens(:one).secret
+    
+    # ユーザーAのAPIトークンのdescriptionが表示されていることを確認
+    assert_includes @response.body, api_tokens(:one).description
+  end
 end

--- a/test/fixtures/api_tokens.yml
+++ b/test/fixtures/api_tokens.yml
@@ -1,13 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  secret: MyString
-  description: MyString
+  secret: secret_token_for_user_one_abc123
+  description: Token for User One
   expired_at: 2021-08-27 20:27:00
-  user_id: one
+  user: one
 
 two:
-  secret: MyString
-  description: MyString
+  secret: secret_token_for_user_two_xyz789
+  description: Token for User Two
   expired_at: 2021-08-27 20:27:00
-  user_id: two
+  user: two


### PR DESCRIPTION
## 概要
ユーザ詳細画面で，ログインしていないユーザの画面にログインしているユーザの API キーが表示されるようになっていた．

## 変更点
- `UsersController` で表示中のユーザがログインユーザと同じ場合のみトークンを取得．
- 表示中のユーザがログインユーザと同じ場合のみ API トークンのセクションを表示するように変更．